### PR TITLE
rohmu add ci pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,77 @@
+name: Build rohmu
+
+# Default to read-only access to all APIs.
+permissions: read-all
+
+on:
+  push:
+    branches:
+      - import
+    tags:
+      - '**'
+  pull_request:
+
+jobs:
+
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # only use one version for the lint step
+        python-version: [3.9]
+
+    steps:
+
+      - id: checkout-code
+        uses: actions/checkout@v2
+        with:
+          # Do not persist the token during execution of this job.
+          persist-credentials: false
+
+      - id: prepare-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - id: dependencies
+        run: |
+          pip install -r requirements.txt
+      - id: pylint
+        run: make lint
+
+      - id: mypy
+        run: make mypy
+
+      # Disabling for now since this is reformatting a lot of file.
+      # - id: validate-style
+      #  run: |
+      #    make fmt
+      #    if [ $(git diff --name-only --diff-filter=ACMR | wc -l ) != 0 ]; then
+      #      echo "Reformatting failed! Please run make fmt on your commits and resubmit!" 1>&2;
+      #      git diff;
+      #      exit 1;
+      #    fi
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.9, 3.8, 3.7, 3.6]
+
+    steps:
+      - id: checkout-code
+        uses: actions/checkout@v2
+
+      - id: prepare-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - id: dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements.dev.txt
+
+      - id: unittest
+        run: make coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,3 +76,9 @@ jobs:
 
       - id: unittest
         run: make coverage
+
+      - id: upload-codecov
+        # Third-party action pinned to v2.1.0
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b
+        with:
+          verbose: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
       - id: dependencies
         run: |
           pip install -r requirements.txt
+          pip install -r requirements.dev.txt
       - id: pylint
         run: make lint
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ permissions: read-all
 on:
   push:
     branches:
-      - import
+      - main
     tags:
       - '**'
   pull_request:

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,38 @@
+[MESSAGES CONTROL]
+disable=
+    bad-option-value,
+    duplicate-code,
+    fixme,
+    import-outside-toplevel,
+    invalid-name,
+    len-as-condition,
+    locally-disabled,
+    missing-docstring,
+    no-else-raise,
+    no-else-return,
+    no-self-use,
+    raise-missing-from,
+    too-few-public-methods,
+    too-many-ancestors,
+    too-many-arguments,
+    too-many-boolean-expressions,
+    too-many-branches,
+    too-many-function-args,
+    too-many-instance-attributes,
+    too-many-locals,
+    too-many-public-methods,
+    too-many-statements,
+    ungrouped-imports,
+    wrong-import-order,
+    wrong-import-position
+
+[FORMAT]
+max-line-length=125
+max-module-lines=1100
+
+[REPORTS]
+output-format=text
+reports=no
+
+[TYPECHECK]
+extension-pkg-whitelist=pydantic

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 0%
+       # advanced settings
+        if_ci_failed: error #success, failure, error, ignore
+        only_pulls: false
+        if_not_found: failure
+

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,29 @@
+[mypy]
+python_version = 3.9
+warn_redundant_casts = True
+
+
+[mypy-azure.*]
+ignore_missing_imports = True
+
+[mypy-azure.common.*]
+ignore_missing_imports = True
+
+[mypy-dataclasses.*]
+ignore_missing_imports = True
+
+[mypy-googleapiclient.*]
+ignore_missing_imports = True
+
+[mypy-oauth2client.*]
+ignore_missing_imports = True
+
+[mypy-snappy.*]
+ignore_missing_imports = True
+
+[mypy-swiftclient.*]
+ignore_missing_imports = True
+
+[mypy-systemd.*]
+ignore_missing_imports = True
+

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 # Lock mypy to the same major version used in downstream build environments
-mypy>=0.931,<1.0
+mypy
 # Same version from pghoard
 pylint>=2.4.3,<=2.7.2
 pylint-quotes

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,6 +5,7 @@ pylint>=2.4.3,<=2.7.2
 pylint-quotes
 pytest
 pytest-cov
+pytest-mock
 # Same version from pghoard
 yapf==0.30.0
 isort==5.7.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-# Lock mypy to the same major version used in downstream build environments
+# same versions than pghoard this must reviewed and pinned
 mypy
 # Same version from pghoard
 pylint>=2.4.3,<=2.7.2
@@ -8,6 +8,7 @@ pytest-cov
 # Same version from pghoard
 yapf==0.30.0
 isort==5.7.0
+unify
 types-python-dateutil
 types-paramiko
 types-botocore

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,10 @@
+# Lock mypy to the same major version used in downstream build environments
+mypy>=0.931,<1.0
+# Same version from pghoard
+pylint>=2.4.3,<=2.7.2
+pylint-quotes
+pytest
+pytest-cov
+# Same version from pghoard
+yapf==0.30.0
+isort==5.7.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,3 +8,7 @@ pytest-cov
 # Same version from pghoard
 yapf==0.30.0
 isort==5.7.0
+types-python-dateutil
+types-paramiko
+types-botocore
+types-httplib2

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,9 +3,11 @@ from rohmu.object_storage.local import LocalTransfer
 from rohmu.delta.snapshot import Snapshotter
 from rohmu.delta.common import EMBEDDED_FILE_SIZE, Progress
 
+
 @pytest.fixture(name="local_transfer")
 def local_transfer(tmp_path):
     return LocalTransfer(tmp_path / "local_storage")
+
 
 class SnapshotterWithDefaults(Snapshotter):
     def create_4foobar(self):

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -1,7 +1,7 @@
 import pytest
-from conftest import local_transfer
 from rohmu import errors
 from io import BytesIO
+
 
 @pytest.mark.parametrize("transfer",
                          ["local_transfer"])
@@ -20,6 +20,7 @@ def test_nonexistent(transfer, request):
     assert transfer.list_path("") == []
     assert transfer.list_path("NONEXISTENT") == []
 
+
 @pytest.mark.parametrize("transfer",
                          ["local_transfer"])
 def test_basic_upload(transfer, tmp_path, request):
@@ -30,7 +31,7 @@ def test_basic_upload(transfer, tmp_path, request):
     assert transfer.get_contents_to_string("x1") == (b"dummy", {"k": "v"})
     # Same thing, but with a key looking like a directory
     transfer.store_file_from_memory("NONEXISTENT-DIR/x1", b"dummy", None)
-    transfer.get_contents_to_string("x1") == (b"dummy", None)
+    assert transfer.get_contents_to_string("x1") == (b"dummy", None)
 
     # Same thing, but from disk now
     dummy_file= scratch / "a"

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -31,7 +31,7 @@ def test_basic_upload(transfer, tmp_path, request):
     assert transfer.get_contents_to_string("x1") == (b"dummy", {"k": "v"})
     # Same thing, but with a key looking like a directory
     transfer.store_file_from_memory("NONEXISTENT-DIR/x1", b"dummy", None)
-    assert transfer.get_contents_to_string("x1") == (b"dummy", None)
+    assert transfer.get_contents_to_string("NONEXISTENT-DIR/x1") == (b"dummy", {})
 
     # Same thing, but from disk now
     dummy_file= scratch / "a"


### PR DESCRIPTION
Adding ci pipeline to run lint and test on main and pull requests. Also, uploading coverage to codecov (todo: after running tests). Based on pghoard (using same version) to avoid change a lot of files in this initial step.

Resolves: https://github.com/aiven/rohmu/issues/2 and https://github.com/aiven/rohmu/issues/14