### PR TITLE
Publish to PyPI with GitHub Action

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,0 +1,44 @@
+# Based on https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+name: Publish to PyPI
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  build-n-publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+
+    - name: Install pypa/build
+      run: >-
+        python -m pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Verify tag is annotated
+      if: startsWith(github.ref, 'refs/tags')
+      run: >-
+        test $(git for-each-ref --format='%(objecttype)' ${GITHUB_REF}) == tag
+    - name: Publish distribution to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Was copy-pasted from https://github.com/aiven/aiven-client/blob/main/.github/workflows/publish-pypi.yaml
Decided to use the lowest supported python version, but did not find any for or against it.