### PR TITLE
Support azure authentication with SAS token

### DIFF
--- a/rohmu.spec
+++ b/rohmu.spec
@@ -5,6 +5,9 @@ Url:            https://github.com/aiven/rohmu
 Summary:        Object storage encryption and compression library
 License:        ASL 2.0
 Source0:        rohmu-rpm-src.tar
+Requires:       python3-azure-common
+Requires:       python3-azure-core
+Requires:       python3-azure-storage-blob
 Requires:       python3-botocore
 Requires:       python3-cryptography >= 0.8
 Requires:       python3-dateutil


### PR DESCRIPTION
## Summary
AzureTransfer currently only authenticates using a Service Account name and secret, which does not allow for granular permissions. Adding SAS token authentication to allow more restrictive permissions to be applied to the Storage Account where backups are stored.

Had an existing [PR](https://github.com/aiven/pghoard/pull/509) for this in pghoard, but recreating it since the rohmu project is being moved out of pghoard.

## Why this way
Having the option to authenticate via SAS token (see [Azure docs](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview) for more info) provides more flexibility to decide which permissions are granted to an Azure service, and can be easily revoked if the token ever becomes compromised. This is better than using the Service Account credentials, since they can only provide full read/write/delete access to the service, and can not be as easily revoked. 
