### PR TITLE
Add possibility to identify small files when doing delta backup

### DIFF
--- a/test/test_delta.py
+++ b/test/test_delta.py
@@ -1,13 +1,21 @@
 # Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
 import os
+from pathlib import Path
 
 import pytest
 
-from rohmu.delta.common import Progress, SnapshotHash
+from rohmu.delta.common import EMBEDDED_FILE_SIZE, Progress, SnapshotHash
 
 
 @pytest.mark.timeout(2)
-def test_snapshot(snapshotter):
+def test_snapshot(snapshotter_creator):
+    snapshotter = snapshotter_creator()
+    samples = {
+        "foo": "foobar",
+        "foo2": "foobar",
+        "foobig": "foobar" * EMBEDDED_FILE_SIZE,
+        "foobig2": "foobar" * EMBEDDED_FILE_SIZE
+    }
     with snapshotter.lock:
         # Start with empty
         assert snapshotter.snapshot(progress=Progress()) == 0
@@ -16,7 +24,7 @@ def test_snapshot(snapshotter):
         assert not (dst / "foo").is_file()
 
         # Create files in src, run snapshot
-        snapshotter.create_4foobar()
+        snapshotter.create_samples(samples=samples)
         ss2 = snapshotter.get_snapshot_state()
 
         assert (dst / "foo").is_file()
@@ -63,12 +71,13 @@ def test_snapshot(snapshotter):
 
 
 @pytest.mark.parametrize("test", [(os, "link", 1, 1), (None, "_snapshotfile_from_path", 3, 0)])
-def test_snapshot_error_filenotfound(snapshotter, mocker, test):
+def test_snapshot_error_filenotfound(snapshotter_creator, mocker, test):
     (obj, fun, exp_progress_1, exp_progress_2) = test
 
     def _not_really_found(*a, **kw):
         raise FileNotFoundError
 
+    snapshotter = snapshotter_creator()
     obj = obj or snapshotter
     mocker.patch.object(obj, fun, new=_not_really_found)
     (snapshotter.src / "foo").write_text("foobar")
@@ -78,3 +87,48 @@ def test_snapshot_error_filenotfound(snapshotter, mocker, test):
         assert snapshotter.snapshot(progress=progress) == exp_progress_1
         progress = Progress()
         assert snapshotter.snapshot(progress=progress) == exp_progress_2
+
+
+@pytest.mark.timeout(2)
+def test_snapshot_single_file_size(snapshotter_creator):
+    snapshotter = snapshotter_creator(min_delta_file_size=1024 * 1024)
+    samples = {
+        "embed1": "foobar",
+        "embed2": "foobar",
+        "bundle1": "foobar" * EMBEDDED_FILE_SIZE,
+        "bundle2": "foobar" * EMBEDDED_FILE_SIZE,
+        "big1": "x" * 2 * 1024 * 1024,
+        "big2": "y" * 1 * 1024 * 1024
+    }
+    with snapshotter.lock:
+        snapshotter.snapshot(progress=Progress())
+        snapshotter.create_samples(samples=samples)
+
+        hashes = snapshotter.get_snapshot_hashes()
+        assert all(Path(file_name) in snapshotter.relative_path_to_snapshotfile for file_name in ["bundle1", "bundle2"])
+
+        for file_name, snapshot_file in snapshotter.relative_path_to_snapshotfile.items():
+            assert snapshot_file.should_be_bundled == (str(file_name) in ["bundle1", "bundle2"])
+
+        assert len(hashes) == 2
+        assert hashes == [
+            SnapshotHash(hexdigest="d7e01e55405fb81256298fb37916f090bee99b274d0b9fdfc8c6ea6a0dc7797e", size=2097152),
+            SnapshotHash(hexdigest="55924e2033f99b59100385820daeaa2623cbf4a2061831dc44be63506c8a255a", size=1048576),
+        ]
+        # Create two more files, one of which should be bundled and another one should be a usual delta hash file
+        snapshotter.create_samples(samples={"bundle3": "1" * (1024 * 1024 - 1)})
+        snapshotter.create_samples(samples={"big3": "2" * (1024 * 1024)})
+        snapshotter.snapshot()
+
+        hashes = snapshotter.get_snapshot_hashes()
+        bundled_file = snapshotter.relative_path_to_snapshotfile.get(Path("bundle3"))
+        assert bundled_file.should_be_bundled and not bundled_file.hexdigest
+        hexdigest_file = snapshotter.relative_path_to_snapshotfile.get(Path("big3"))
+        assert not hexdigest_file.should_be_bundled and hexdigest_file.hexdigest
+
+        assert len(hashes) == 3
+        assert hashes == [
+            SnapshotHash(hexdigest="d7e01e55405fb81256298fb37916f090bee99b274d0b9fdfc8c6ea6a0dc7797e", size=2097152),
+            SnapshotHash(hexdigest="55924e2033f99b59100385820daeaa2623cbf4a2061831dc44be63506c8a255a", size=1048576),
+            SnapshotHash(hexdigest="4ac533296ea373a0bdbe5f1ae8fda6b2e908399a528a5e10fe2eca3ed058403f", size=1048576),
+        ]

--- a/test/test_rohmufile.py
+++ b/test/test_rohmufile.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
 
+from io import BytesIO
+from tempfile import NamedTemporaryFile
+
 import pytest
 
-from io import BytesIO
 from rohmu import rohmufile
 from rohmu.errors import InvalidConfigurationError
-from tempfile import NamedTemporaryFile
 
 
 def test_fileobj_name(tmpdir):


### PR DESCRIPTION
Sometimes it's useful to not treat small files as separate delta backup
hash files, rather consider them a part of bundle which can be managed
separately. E.g. in cases where we don't want to upload such files to the
object storage separately, rather upload only big enough files, but the
small ones put together and upload as an archived bundle. We don't need to
bother calculating hash in this case even. We could have done the same
for embed files as well, but this should stay for backward compatibility.