### PR TITLE
add utils to remove pghoard dependencies

### DIFF
--- a/rohmu/util.py
+++ b/rohmu/util.py
@@ -1,0 +1,47 @@
+"""
+rohmu - common utility functions
+
+Copyright (c) 2022 Ohmu Ltd
+See LICENSE for details
+"""
+import fcntl
+import logging
+import os
+import platform
+
+LOG = logging.getLogger("rohmu.util")
+
+
+def increase_pipe_capacity(*pipes):
+    if platform.system() != "Linux":
+        return
+    try:
+        with open("/proc/sys/fs/pipe-max-size", "r") as f:
+            pipe_max_size = int(f.read())
+    except FileNotFoundError:
+        return
+    # Attempt to get as big pipe as possible; as Linux pipe usage quotas are
+    # account wide (and not visible to us), brute-force attempting is
+    # the best we can do.
+    #
+    # F_SETPIPE_SZ can also return EBUSY if trying to shrink pipe from
+    # what is in the buffer (not true in our case as pipe should be
+    # growing), or ENOMEM, and we bail in both of those cases.
+    for pipe in pipes:
+        for shift in range(0, 16):
+            size = pipe_max_size >> shift
+            if size <= 65536:
+                # Default size
+                LOG.warning("Unable to grow pipe buffer at all, performance may suffer")
+                return
+            try:
+                fcntl.fcntl(pipe, 1031, pipe_max_size)  # F_SETPIPE_SZ
+                break
+            except PermissionError:
+                pass
+
+
+def set_stream_nonblocking(stream):
+    fd = stream.fileno()
+    fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)


### PR DESCRIPTION
Certain utilities from pghoard are used in other projects. Specifically, [myhoard](https://github.com/aiven/myhoard/pull/78) uses `increase_pipe_capacity()` and `set_stream_nonblocking()`. Duplicating those util methods in rohmu allows myhoard (and possibly other projects) to be entirely freed of pghoard dependency.
