### PR TITLE
Unpin azure-storage-blob dependency [BF-1215]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,8 @@ jobs:
 
       - id: dependencies
         run: |
-          pip install -r requirements.txt
-          pip install -r requirements.dev.txt
+          pip install --upgrade -r requirements.txt
+          pip install --upgrade -r requirements.dev.txt
       - id: pylint
         run: make lint
 

--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -17,7 +17,7 @@ try:
     from azure.storage.blob import BlobPrefix, BlobType
 except ImportError:
     # old versions of the azure blob storage library do not expose the classes publicly
-    from azure.storage.blob._models import BlobPrefix, BlobType
+    from azure.storage.blob._models import BlobPrefix, BlobType  # type: ignore
 
 from ..errors import (FileNotFoundFromStorageError, InvalidConfigurationError, StorageError)
 from .base import (KEY_TYPE_OBJECT, KEY_TYPE_PREFIX, BaseTransfer, IterKeyItem, get_total_memory)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ package_dir =
     =.
 packages = find:
 install_requires =
-    azure-storage-blob == 2.1.0
+    azure-storage-blob >= 2.1.0
     botocore
     cryptography
     google-api-python-client


### PR DESCRIPTION
Requiring a specific version of azure-storage-blob seems unnecessary, we want to use much newer version