### PR TITLE
Delta: fail backup if required files are missing [BF-1203]

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,15 +1,16 @@
 # same versions than pghoard this must reviewed and pinned
 black==22.3.0
+mock
 mypy
 # Same version from pghoard
 pylint>=2.4.3,<=2.7.2
 pylint-quotes
 pytest
 pytest-cov
-pytest-mock
 # Same version from pghoard
 isort==5.10.1
 types-python-dateutil
 types-paramiko
 types-botocore
 types-httplib2
+types-mock

--- a/rohmu/delta/common.py
+++ b/rohmu/delta/common.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+from dataclasses import dataclass
 from datetime import datetime
 from multiprocessing.dummy import Pool
 from pathlib import Path
@@ -148,6 +149,7 @@ class SnapshotFile(DeltaModel):
     # separate delta hash files, but not small enough to be embedded into a manifest file, so better to group them
     # together when e.g. uploading to the object storage
     should_be_bundled: bool = False
+    missing_ok: bool = True
 
     def __lt__(self, o):
         # In our use case, paths uniquely identify files we care about
@@ -289,3 +291,9 @@ def parallel_map_to(*, fun, iterable, result_callback, n=None) -> bool:
             if not result_callback(map_in=map_in, map_out=map_out):
                 return False
     return True
+
+
+@dataclass(frozen=True)
+class BackupPath:
+    path: Path
+    missing_ok: bool = True


### PR DESCRIPTION
# About this change - What it does
Add support for required backup files, in case if file is missing the backup should fail.

# Why this way
This is the simplest approach, as file might disappear at any point in time. This solution is not very memory efficient as it needs to keep in memory all the required paths while doing snapshot, but it should suffice for the time being, for around 1 million of paths, it would take around ~10-100 megabytes, but I guess this snapshotting part in general might be improved in terms of memory efficiency.

