### PR TITLE
make sure that compression threads config can be passed for calls to …

### DIFF
--- a/rohmu/rohmufile.py
+++ b/rohmu/rohmufile.py
@@ -117,6 +117,7 @@ def write_file(
     progress_callback=None,
     compression_algorithm=None,
     compression_level=0,
+    compression_threads=0,
     rsa_public_key=None,
     log_func=None,
     header_func=None,
@@ -128,6 +129,7 @@ def write_file(
     with file_writer(
         fileobj=output_obj,
         compression_algorithm=compression_algorithm,
+        compression_threads=compression_threads,
         compression_level=compression_level,
         rsa_public_key=rsa_public_key,
     ) as fp_out:


### PR DESCRIPTION
…write_file

<!-- All contributors please complete these sections, including maintainers -->
It adds compression_threads as a parameter to write_file so  that it gets passed to the call to file_writer. It is useful to be able to pass threads config when calling write_file rather than file_writer.

<!-- Provide a small sentence that summarizes the change. -->
Adds compression_threads parameter (with a default) to rohmufile.py

<!-- Provide the issue number below if it exists. -->
None

# Why this way
The simplest approach is the best
<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

