### PR TITLE
 teach rohmu to notifiy when it writes anything [AD-756]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools', 'wheel']
+requires = ['setuptools', 'wheel', 'requests']
 build-backend = 'setuptools.build_meta'
 
 [tool.black]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -14,3 +14,4 @@ types-paramiko
 types-botocore
 types-httplib2
 types-mock
+types-requests

--- a/rohmu/__init__.py
+++ b/rohmu/__init__.py
@@ -45,4 +45,7 @@ def get_transfer(storage_config) -> BaseTransfer:
     storage_class = get_class_for_transfer(storage_config)
     storage_config = storage_config.copy()
     storage_config.pop("storage_type")
-    return storage_class(**storage_config)
+    notification_url = storage_config.pop("notification_url", None)
+    ret = storage_class(**storage_config)
+    ret.update_notification_url(notification_url)
+    return ret

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -271,11 +271,13 @@ class GoogleTransfer(BaseTransfer):
                     raise NotImplementedError(property_name)
 
     def delete_key(self, key):
+        plain_key = key
         key = self.format_key_for_backend(key)
         self.log.debug("Deleting key: %r", key)
         with self._object_client(not_found=key) as clob:
             req = clob.delete(bucket=self.bucket_name, object=key)
             self._retry_on_reset(req, req.execute)
+        self.notify_delete(plain_key)
 
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
         fileobj = FileIO(filepath_to_store_to, mode="wb")
@@ -363,7 +365,8 @@ class GoogleTransfer(BaseTransfer):
         upload = MediaIoBaseUpload(
             BytesIO(memstring), mimetype or "application/octet-stream", chunksize=UPLOAD_CHUNK_SIZE, resumable=True
         )
-        return self._upload(upload, key, self.sanitize_metadata(metadata), extra_props, cache_control=cache_control)
+        self._upload(upload, key, self.sanitize_metadata(metadata), extra_props, cache_control=cache_control)
+        self.notify_write(key=key, size=len(bytes(memstring)))
 
     # pylint: disable=arguments-differ
     def store_file_from_disk(
@@ -379,11 +382,13 @@ class GoogleTransfer(BaseTransfer):
     ):
         mimetype = mimetype or "application/octet-stream"
         upload = MediaFileUpload(filepath, mimetype, chunksize=UPLOAD_CHUNK_SIZE, resumable=True)
-        return self._upload(upload, key, self.sanitize_metadata(metadata), extra_props, cache_control=cache_control)
+        self._upload(upload, key, self.sanitize_metadata(metadata), extra_props, cache_control=cache_control)
+        size = os.path.getsize(filepath)
+        self.notify_write(key=key, size=size)
 
     def store_file_object(self, key, fd, *, cache_control=None, metadata=None, mimetype=None, upload_progress_fn=None):
         mimetype = mimetype or "application/octet-stream"
-        return self._upload(
+        self._upload(
             MediaStreamUpload(fd, chunk_size=UPLOAD_CHUNK_SIZE, mime_type=mimetype, name=key),
             key,
             self.sanitize_metadata(metadata),
@@ -391,6 +396,7 @@ class GoogleTransfer(BaseTransfer):
             cache_control=cache_control,
             upload_progress_fn=upload_progress_fn,
         )
+        self.notify_write(key=key, size=self.get_file_size(key))
 
     def get_or_create_bucket(self, bucket_name):
         """Look up the bucket if it already exists and try to create the

--- a/test/test_notification.py
+++ b/test/test_notification.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+from rohmu import get_transfer
+from unittest.mock import MagicMock, patch
+
+import datetime
+import tempfile
+import uuid
+
+
+def test_setting_notification_url():
+    with tempfile.TemporaryDirectory(prefix="rohmu-") as local:
+        config = {"directory": str(local), "storage_type": "local", "notification_url": "http://notify/here"}
+        transfer = get_transfer(config)
+        assert transfer.notification_url == config["notification_url"]
+        assert transfer.notifier is not None
+
+
+@patch("rohmu.object_storage.base.ThreadPoolExecutor")
+def test_notifiy_delete():
+    with tempfile.TemporaryDirectory(prefix="rohmu-") as local:
+        config = {"directory": str(local), "storage_type": "local", "notification_url": "http://notify/here"}
+        transfer = get_transfer(config)
+        key = str(uuid.uuid4())
+        transfer.notify_delete(key=key)
+        op = {"key": key, "op": "DELETE"}
+        transfer.notifier.submit.assert_called_once_with(transfer._notify, op)  # pylint: disable=protected-access, no-member
+
+
+@patch("rohmu.object_storage.base.datetime")
+@patch("rohmu.object_storage.base.ThreadPoolExecutor")
+def test_notifiy_upload(mocked_executor, mock_datetime):  # pylint: disable=unused-argument
+    with tempfile.TemporaryDirectory(prefix="rohmu-") as local:
+        config = {"directory": str(local), "storage_type": "local", "notification_url": "http://notify/here"}
+        transfer = get_transfer(config)
+        utcnow = datetime.datetime.utcnow()
+        mock_datetime.datetime.utcnow.return_value = utcnow
+        key = str(uuid.uuid4())
+        op = {"key": key, "op": "UPLOAD", "size_bytes": 100, "last_modified": utcnow}
+        transfer.notify_write(key=key, size=100)
+        transfer.notifier.submit.assert_called_once_with(transfer._notify, op)  # pylint: disable=protected-access, no-member
+
+
+@patch("rohmu.object_storage.base.get_requests_session")
+def test_notifiy_request(mock_session):
+    url = "http://notify/here"
+    with tempfile.TemporaryDirectory(prefix="rohmu-") as local:
+        config = {
+            "directory": str(local),
+            "storage_type": "local",
+            "notification_url": url,
+        }
+        mock_enter = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_enter
+        op = {"key": str(uuid.uuid4()), "op": "DELETE"}
+        transfer = get_transfer(config)
+        transfer._notify(op)  # pylint: disable=protected-access
+        mock_enter.post.assert_called_once_with(url, json=op)


### PR DESCRIPTION
This allows robjecter to be informed everytime pghoard (rohmu) writes
anything. This can be controlled with the presence of extra config
passed to the constructors of each object storage driver.

The plain_key is needed as robjecter itself uses rohmu so the prefix
gets prefixed twice.
size is not strictly needed but helps make robjecter's work easier. And
here size is easily available statically or dynamically (in case of
multipart-uploads). In case of multipart uploads the size could
calculated using the callback mechanisms locally however each driver
reports callback in a different manner and in some cases the callback
might not be called if a multipart upload was not necessary.

NOTE: this just replays aiven/pghoard/pull/548 here 

[AD-756]

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->



[AD-756]: https://aiven.atlassian.net/browse/AD-756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ