### PR TITLE
drop support for Python 3.6 [EOL 23/Dec/2021]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9, 3.8, 3.7, 3.6]
+        python-version: [3.10, 3.9, 3.8, 3.7]
 
     steps:
       - id: checkout-code

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
 
     - name: Install pypa/build
       run: >-

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Features
 Requirements
 ============
 
-Rohmu requires Python >= 3.6+. For Python libary dependencies, have a
+Rohmu requires Python >= 3.7. For Python libary dependencies, have a
 look at
 `requirements.txt <https://github.com/aiven/rohmu/blob/main/requirements.txt>`__.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ classifiers =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
As the tile says, 3.6 has reached EOL last year