### PR TITLE
build: fix python version on yaml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # only use one version for the lint step
-        python-version: [3.9]
+        python-version: ["3.9"]
 
     steps:
 
@@ -57,7 +57,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10, 3.9, 3.8, 3.7]
+        python-version: ["3.10", "3.9", "3.8", "3.7"]
 
     steps:
       - id: checkout-code

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: "3.7"
 
     - name: Install pypa/build
       run: >-


### PR DESCRIPTION
The value `3.10` is parsed as an integer and the right most zero is dropped. The effect is that GH CI tried to run the build using python 3.1 instead of 3.10. The fix is to use strings to define the version instead of numbers.