### PR TITLE
Make sure get_contents_to_file() calls are atomic

### DIFF
--- a/rohmu/atomic_opener.py
+++ b/rohmu/atomic_opener.py
@@ -1,18 +1,31 @@
 from contextlib import contextmanager
 from pathlib import Path
-from typing import (
-    BinaryIO,
-    Callable,
-    cast,
-    ContextManager,
-    Generator,
-    Literal,
-    Optional,
-    overload,
-    TextIO,
-    TYPE_CHECKING,
-    Union,
-)
+from typing import BinaryIO, Callable, cast, ContextManager, Generator, Optional, overload, TextIO, TYPE_CHECKING, Union
+
+# workaround < Python3.8 missing Literal.
+# if we just use the try/except block, mypy will complain
+# about the fact that Write* variables are being redefined.
+# so we need to pour in an additional branch.
+if TYPE_CHECKING:
+    from typing import Literal
+
+    Write = Literal["w"]
+    WriteBinary = Literal["wb"]
+    WriteTest = Literal["somethingrandomw"]
+else:
+    try:
+        from typing import Literal
+
+        Write = Literal["w"]
+        WriteBinary = Literal["wb"]
+        WriteTest = Literal["somethingrandomw"]
+    except ImportError:
+        from typing import Any
+
+        Write = Any
+        WriteBinary = Any
+        WriteTest = Any
+
 
 import errno
 import os
@@ -31,7 +44,7 @@ def _fd_close_quietly(fd: int) -> None:
 @overload
 def atomic_opener(
     final_path: Path,
-    mode: Literal["wb"],
+    mode: WriteBinary,
     encoding: Optional[str] = None,
     _fd_spy: Callable[[int], None] = lambda unused: None,
     _after_link_hook: Callable[[], None] = lambda: None,
@@ -42,7 +55,7 @@ def atomic_opener(
 @overload
 def atomic_opener(
     final_path: Path,
-    mode: Literal["w"],
+    mode: Write,
     encoding: Optional[str] = None,
     _fd_spy: Callable[[int], None] = lambda unused: None,
     _after_link_hook: Callable[[], None] = lambda: None,
@@ -55,7 +68,7 @@ if TYPE_CHECKING:
     @overload
     def atomic_opener(
         final_path: Path,
-        mode: Literal["somethingrandomw"],
+        mode: WriteTest,
         encoding: Optional[str] = None,
         _fd_spy: Callable[[int], None] = lambda unused: None,
         _after_link_hook: Callable[[], None] = lambda: None,

--- a/rohmu/atomic_opener.py
+++ b/rohmu/atomic_opener.py
@@ -1,0 +1,115 @@
+from contextlib import contextmanager
+from pathlib import Path
+from typing import (
+    BinaryIO,
+    Callable,
+    cast,
+    ContextManager,
+    Generator,
+    Literal,
+    Optional,
+    overload,
+    TextIO,
+    TYPE_CHECKING,
+    Union,
+)
+
+import errno
+import os
+
+
+def _fd_close_quietly(fd: int) -> None:
+    try:
+        os.close(fd)
+    except OSError as e:
+        if e.errno == errno.EBADF:
+            # closed already
+            return
+        raise
+
+
+@overload
+def atomic_opener(
+    final_path: Path,
+    mode: Literal["wb"],
+    encoding: Optional[str] = None,
+    _fd_spy: Callable[[int], None] = lambda unused: None,
+    _after_link_hook: Callable[[], None] = lambda: None,
+) -> ContextManager[BinaryIO]:
+    ...
+
+
+@overload
+def atomic_opener(
+    final_path: Path,
+    mode: Literal["w"],
+    encoding: Optional[str] = None,
+    _fd_spy: Callable[[int], None] = lambda unused: None,
+    _after_link_hook: Callable[[], None] = lambda: None,
+) -> ContextManager[TextIO]:
+    ...
+
+
+if TYPE_CHECKING:
+    # necessary for testing or tests will fail type checking
+    @overload
+    def atomic_opener(
+        final_path: Path,
+        mode: Literal["somethingrandomw"],
+        encoding: Optional[str] = None,
+        _fd_spy: Callable[[int], None] = lambda unused: None,
+        _after_link_hook: Callable[[], None] = lambda: None,
+    ) -> ContextManager[TextIO]:
+        ...
+
+
+def atomic_opener(
+    final_path: Path,
+    mode: str,
+    encoding: Optional[str] = None,
+    _fd_spy: Callable[[int], None] = lambda unused: None,
+    _after_link_hook: Callable[[], None] = lambda: None,
+) -> ContextManager[Union[TextIO, BinaryIO]]:
+    return _atomic_opener(final_path, mode, encoding, _fd_spy, _after_link_hook)
+
+
+@contextmanager
+def _atomic_opener(
+    final_path: Path,
+    mode: str,
+    encoding: Optional[str] = None,
+    _fd_spy: Callable[[int], None] = lambda unused: None,
+    _after_link_hook: Callable[[], None] = lambda: None,
+) -> Generator[Union[TextIO, BinaryIO], None, None]:
+    """
+    Creates a file object for writing which will only appear on the filesystem if the context manager succeeds.
+
+    It's designed to prevent partial writes (file will either be available with full content, or will be unavailable)
+    and the need for manual cleanup.
+    """
+    parent_dir = final_path.parent
+    if not parent_dir.exists():
+        raise IOError(f"Parent directory '{parent_dir}' must exist but is missing")
+    if "w" not in mode:
+        raise ValueError("Write mode must be used to make actual sense")
+
+    fd = os.open(str(parent_dir), os.O_TMPFILE | os.O_RDWR, 0o600)
+    _fd_spy(fd)
+    try:
+        file_obj = os.fdopen(fd, mode=mode, encoding=encoding)
+    except Exception:  # pylint: disable=broad-except
+        # when passing wrong mode, os.fdopen won't close input fd. When passing wrong encoding, it will.
+        _fd_close_quietly(fd)
+        raise
+
+    try:
+        if "b" in mode:
+            yield cast(BinaryIO, file_obj)
+        else:
+            yield cast(TextIO, file_obj)
+        file_obj.flush()
+        path = "/proc/self/fd/{0}".format(fd)
+        os.link(path, str(final_path), src_dir_fd=0, follow_symlinks=True)
+        _after_link_hook()
+    finally:
+        file_obj.close()

--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -11,6 +11,8 @@ from ..notifier.interface import Notifier
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.storage.blob import BlobServiceClient, ContentSettings
 from io import BytesIO
+from pathlib import Path
+from rohmu.atomic_opener import atomic_opener
 
 import azure.common
 import logging
@@ -220,7 +222,7 @@ class AzureTransfer(BaseTransfer):
 
         self.log.debug("Starting to fetch the contents of: %r to: %r", path, filepath_to_store_to)
         try:
-            with open(filepath_to_store_to, "wb") as f:
+            with atomic_opener(Path(filepath_to_store_to), mode="wb") as f:
                 container_client = self.conn.get_container_client(self.container_name)
                 container_client.download_blob(path).readinto(f)
         except azure.core.exceptions.ResourceNotFoundError as ex:  # pylint: disable=no-member

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -6,7 +6,6 @@ Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/
 See LICENSE for details
 """
 # pylint: disable=import-error, no-name-in-module
-
 from ..dates import parse_timestamp
 from ..errors import FileNotFoundFromStorageError, InvalidConfigurationError
 from ..notifier.interface import Notifier
@@ -16,9 +15,11 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from googleapiclient.http import build_http, MediaFileUpload, MediaIoBaseDownload, MediaIoBaseUpload, MediaUpload
 from http.client import IncompleteRead
-from io import BytesIO, FileIO
+from io import BytesIO
 from oauth2client import GOOGLE_TOKEN_URI
 from oauth2client.client import GoogleCredentials
+from pathlib import Path
+from rohmu.atomic_opener import atomic_opener
 
 import codecs
 import errno
@@ -29,7 +30,6 @@ import googleapiclient  # noqa pylint: disable=unused-import
 import httplib2
 import json
 import logging
-import os
 import random
 import socket
 import ssl
@@ -297,17 +297,8 @@ class GoogleTransfer(BaseTransfer):
             self.notifier.object_deleted(key)
 
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
-        fileobj = FileIO(filepath_to_store_to, mode="wb")
-        done = False
-        metadata = {}
-        try:
-            metadata = self.get_contents_to_fileobj(key, fileobj, progress_callback=progress_callback)
-            done = True
-        finally:
-            fileobj.close()
-            if not done:
-                os.unlink(filepath_to_store_to)
-        return metadata
+        with atomic_opener(Path(filepath_to_store_to), mode="wb") as fileobj:
+            return self.get_contents_to_fileobj(key, fileobj, progress_callback=progress_callback)
 
     def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback=None):
         path = self.format_key_for_backend(key)

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -235,18 +235,8 @@ class LocalTransfer(BaseTransfer):
         self.notifier.object_created(key=key, size=os.path.getsize(target_path))
 
 
-@contextlib.contextmanager
 def atomic_create_file(file_path):
-    """Open a temporary file for writing, rename to final name when done"""
-    fd, tmp_file_path = tempfile.mkstemp(
-        prefix=os.path.basename(file_path), dir=os.path.dirname(file_path), suffix=".metadata_tmp"
-    )
-    try:
-        with os.fdopen(fd, "w") as out_file:
-            yield out_file
-
-        os.rename(tmp_file_path, file_path)
-    except Exception:  # pytest: disable=broad-except
-        with contextlib.suppress(Exception):
-            os.unlink(tmp_file_path)
-        raise
+    """
+    Deprecated; use atomic_opener directly.
+    """
+    return atomic_opener(final_path=file_path, mode="w")

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -9,13 +9,14 @@ from ..errors import FileNotFoundFromStorageError, LocalFileIsRemoteFileError
 from ..notifier.interface import Notifier
 from .base import BaseTransfer, IterKeyItem, KEY_TYPE_OBJECT, KEY_TYPE_PREFIX
 from io import BytesIO
+from pathlib import Path
+from rohmu.atomic_opener import atomic_opener
 
 import contextlib
 import datetime
 import json
 import os
 import shutil
-import tempfile
 
 CHUNK_SIZE = 1024 * 1024
 
@@ -148,7 +149,7 @@ class LocalTransfer(BaseTransfer):
             dst_stat = os.stat(filepath_to_store_to)
             if dst_stat.st_dev == src_stat.st_dev and dst_stat.st_ino == src_stat.st_ino:
                 raise LocalFileIsRemoteFileError(source_path)
-        with open(filepath_to_store_to, "wb") as fileobj_to_store_to:
+        with atomic_opener(Path(filepath_to_store_to), mode="wb") as fileobj_to_store_to:
             return self.get_contents_to_fileobj(key, fileobj_to_store_to, progress_callback=progress_callback)
 
     def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback=None):
@@ -183,7 +184,7 @@ class LocalTransfer(BaseTransfer):
 
     def _save_metadata(self, target_path, metadata):
         metadata_path = target_path + ".metadata"
-        with atomic_create_file(metadata_path) as fp:
+        with atomic_opener(Path(metadata_path), mode="w") as fp:
             json.dump(self.sanitize_metadata(metadata), fp)
 
     def store_file_from_memory(self, key, memstring, metadata=None, cache_control=None, mimetype=None):

--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -8,6 +8,8 @@ See LICENSE for details
 from ..errors import FileNotFoundFromStorageError, InvalidConfigurationError, StorageError
 from ..notifier.interface import Notifier
 from .base import BaseTransfer, get_total_memory, IterKeyItem, KEY_TYPE_OBJECT, KEY_TYPE_PREFIX
+from pathlib import Path
+from rohmu.atomic_opener import atomic_opener
 from typing import Dict, Optional
 
 import botocore.client
@@ -253,7 +255,7 @@ class S3Transfer(BaseTransfer):
             cb(data_read, body_length)
 
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
-        with open(filepath_to_store_to, "wb") as fh:
+        with atomic_opener(Path(filepath_to_store_to), mode="wb") as fh:
             stream, length, metadata = self._get_object_stream(key)
             self._read_object_to_fileobj(fh, stream, length, cb=progress_callback)
         return metadata

--- a/rohmu/object_storage/sftp.py
+++ b/rohmu/object_storage/sftp.py
@@ -5,11 +5,12 @@ Copyright (c) 2016 Ohmu Ltd
 Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/
 See LICENSE for details
 """
-
 from ..errors import FileNotFoundFromStorageError, InvalidConfigurationError, StorageError
 from ..notifier.interface import Notifier
 from .base import BaseTransfer, IterKeyItem, KEY_TYPE_OBJECT, KEY_TYPE_PREFIX
 from io import BytesIO, StringIO
+from pathlib import Path
+from rohmu.atomic_opener import atomic_opener
 from stat import S_ISDIR
 from typing import cast
 
@@ -60,7 +61,7 @@ class SFTPTransfer(BaseTransfer):
         self.log.debug("SFTPTransfer initialized")
 
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
-        with open(filepath_to_store_to, "wb") as fh:
+        with atomic_opener(Path(filepath_to_store_to), mode="wb") as fh:
             return self.get_contents_to_fileobj(key, fh, progress_callback=progress_callback)
 
     def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback=None):

--- a/rohmu/object_storage/swift.py
+++ b/rohmu/object_storage/swift.py
@@ -10,6 +10,8 @@ from ..errors import FileNotFoundFromStorageError
 from ..notifier.interface import Notifier
 from .base import BaseTransfer, IterKeyItem, KEY_TYPE_OBJECT, KEY_TYPE_PREFIX
 from contextlib import suppress
+from pathlib import Path
+from rohmu.atomic_opener import atomic_opener
 from swiftclient import client, exceptions  # pylint: disable=import-error
 
 import logging
@@ -195,15 +197,8 @@ class SwiftTransfer(BaseTransfer):
         self.notifier.object_deleted(key=key)
 
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
-        temp_filepath = "{}~".format(filepath_to_store_to)
-        try:
-            with open(temp_filepath, "wb") as fp:
-                metadata = self.get_contents_to_fileobj(key, fp, progress_callback=progress_callback)
-                os.rename(temp_filepath, filepath_to_store_to)
-        finally:
-            with suppress(FileNotFoundError):
-                os.unlink(temp_filepath)
-        return metadata
+        with atomic_opener(Path(filepath_to_store_to), mode="wb") as fp:
+            return self.get_contents_to_fileobj(key, fp, progress_callback=progress_callback)
 
     def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback=None):
         path = self.format_key_for_backend(key)

--- a/test/test_atomic_opener.py
+++ b/test/test_atomic_opener.py
@@ -1,0 +1,145 @@
+from pathlib import Path
+from rohmu.atomic_opener import atomic_opener
+
+import errno
+import os
+import pytest
+import time
+
+
+def _verify_file_not_created_and_dir_not_polluted(output_file: Path):
+    assert os.listdir(output_file.parent) == []
+    assert not output_file.exists()
+
+
+def test_error_thrown_if_final_path_parent_doesnt_exist(tmp_path: Path):
+    with pytest.raises(IOError):
+        with atomic_opener(tmp_path / "nonexistingdir" / "final_path", mode="w") as f:
+            pass
+
+
+def test_error_mode_doesnt_contain_write(tmp_path: Path):
+    with pytest.raises(ValueError):
+        with atomic_opener(tmp_path, mode="r") as f:  # type: ignore
+            pass
+
+
+def test_file_is_atomically_created_only_after_function_execution_is_over(tmp_path: Path):
+    data_block = "x" * 100_000_000
+    # manually tested with block_count of 1000 but it seems overkill to do it every time and it can hog
+    # the testing infra quite a bit.
+    # block_count = 1000
+    block_count = 1
+    size = len(data_block)
+
+    output_file = tmp_path / "something"
+    try:
+        _verify_file_not_created_and_dir_not_polluted(output_file)
+        with atomic_opener(output_file, mode="w") as f:
+            inode_inside = os.stat(f.fileno()).st_ino
+            _verify_file_not_created_and_dir_not_polluted(output_file)
+            for unused_counter in range(block_count):
+                f.write(data_block)
+                f.flush()
+                _verify_file_not_created_and_dir_not_polluted(output_file)
+            timestamp_before_exiting = time.monotonic()
+
+        # this must be super-fast since atomic move is taking place. Makes more sense with
+        # a large - 100ish - block count
+        assert (time.monotonic() - timestamp_before_exiting) < 0.1
+        assert output_file.exists()
+        assert len(os.listdir(output_file.parent)) == 1
+        assert output_file.stat().st_size == size * block_count
+        assert output_file.stat().st_ino == inode_inside
+    finally:
+        # the file can be big, we want to delete it ASAP
+        try:
+            output_file.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def test_file_is_never_created_if_function_breaks(tmp_path: Path):
+    output_file = tmp_path / "something"
+
+    try:
+        _verify_file_not_created_and_dir_not_polluted(output_file)
+        with atomic_opener(output_file, mode="w") as f:
+            _verify_file_not_created_and_dir_not_polluted(output_file)
+            f.write("aaaaaaaaaa")
+            f.flush()
+            _verify_file_not_created_and_dir_not_polluted(output_file)
+            time.sleep(1.0)
+            _verify_file_not_created_and_dir_not_polluted(output_file)
+            raise ValueError("crash")
+        pytest.fail("codepath should never be taken")
+    except ValueError:
+        _verify_file_not_created_and_dir_not_polluted(output_file)
+
+
+def test_file_is_fully_written_if_visible(tmp_path: Path):
+    output_file = tmp_path / "something"
+
+    def linkhook():
+        assert output_file.exists()
+        assert output_file.read_text() == "aaaaaaaaaa"
+
+    try:
+        _verify_file_not_created_and_dir_not_polluted(output_file)
+        with atomic_opener(output_file, mode="w", _after_link_hook=linkhook) as f:
+            _verify_file_not_created_and_dir_not_polluted(output_file)
+            f.write("aaaaaaaaaa")
+            _verify_file_not_created_and_dir_not_polluted(output_file)
+            time.sleep(1.0)
+            _verify_file_not_created_and_dir_not_polluted(output_file)
+
+    except ValueError:
+        _verify_file_not_created_and_dir_not_polluted(output_file)
+
+
+def test_open_for_writing_text_opens_proper_encoding_file(tmp_path: Path):
+    final_path = tmp_path / "file"
+    with atomic_opener(final_path, encoding="iso-8859-1", mode="w") as f:
+        f.write("à")
+    assert final_path.read_bytes() == b"\xe0"
+
+
+def test_open_for_writing_bytes_properly_writes_bytes(tmp_path: Path):
+    final_path = tmp_path / "file"
+    with atomic_opener(final_path, mode="wb") as f:
+        f.write(b"\xe0")
+    assert final_path.read_text("iso-8859-1") == "à"
+
+
+def test_no_fd_leak_if_fdopen_fails_because_of_wrong_encoding(tmp_path: Path):
+    final_path = tmp_path / "file"
+    opened_fd: list[int] = []
+    try:
+        with atomic_opener(final_path, mode="w", encoding="unknownencoding", _fd_spy=opened_fd.append):
+            pass
+        pytest.fail("should fail, encoding is wrong")
+    except LookupError:
+        try:
+            os.fstat(opened_fd[0])
+            pytest.fail("should fail, file descriptor must be invalid")
+        except OSError as e:
+            if e.errno != errno.EBADF:
+                raise
+            # descriptor is invalid, all ok
+
+
+def test_no_fd_leak_if_fdopen_fails_because_of_unknown_mode(tmp_path: Path):
+    final_path = tmp_path / "file"
+    opened_fd: list[int] = []
+    try:
+        with atomic_opener(final_path, mode="somethingrandomw", encoding="ascii", _fd_spy=opened_fd.append):
+            pass
+        pytest.fail("should fail, mode is wrong")
+    except ValueError:
+        try:
+            os.fstat(opened_fd[0])
+            pytest.fail("should fail, file descriptor must be invalid")
+        except OSError as e:
+            if e.errno != errno.EBADF:
+                raise
+            # descriptor is invalid, all ok

--- a/test/test_atomic_opener.py
+++ b/test/test_atomic_opener.py
@@ -14,13 +14,13 @@ def _verify_file_not_created_and_dir_not_polluted(output_file: Path):
 
 def test_error_thrown_if_final_path_parent_doesnt_exist(tmp_path: Path):
     with pytest.raises(IOError):
-        with atomic_opener(tmp_path / "nonexistingdir" / "final_path", mode="w") as f:
+        with atomic_opener(tmp_path / "nonexistingdir" / "final_path", mode="w"):
             pass
 
 
 def test_error_mode_doesnt_contain_write(tmp_path: Path):
     with pytest.raises(ValueError):
-        with atomic_opener(tmp_path, mode="r") as f:  # type: ignore
+        with atomic_opener(tmp_path, mode="r"):  # type: ignore
             pass
 
 


### PR DESCRIPTION
Make sure that calls to get_contents_to_file() are actually atomic

Calls to get_contents_to_file() weren't necessarily atomic - destination file
could be visible before it was completely written, or it could be left half-written
on the filesystem if the process crashed, or it could leave other temporary files
that nothing would cleanup in the same directory as target file.

This was related to some bugs that can be seen in pghoard.

We fix all these issues through an anonymous temporary file approach; details
in commit messages.

Moved over from https://github.com/aiven/rohmu/pull/60 since I changed GH username and the PR wasn't mine anymore.