### PR TITLE
notifier: fix notifications for some storage types, add tests

### DIFF
--- a/test/test_object_storage_azure.py
+++ b/test/test_object_storage_azure.py
@@ -1,0 +1,81 @@
+"""Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from io import BytesIO
+from tempfile import NamedTemporaryFile
+from types import ModuleType
+from typing import Tuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+import sys
+
+
+@pytest.fixture(scope="module", name="mock_azure_module")
+def fixture_mock_azure_module() -> Tuple[ModuleType, MagicMock]:
+    get_blob_client_mock = MagicMock()
+    blob_client = MagicMock(get_blob_client=get_blob_client_mock)
+    service_client = MagicMock(from_connection_string=MagicMock(return_value=blob_client))
+    module_patches = {
+        "azure.common": MagicMock(),
+        "azure.core.exceptions": MagicMock(),
+        "azure.storage.blob": MagicMock(BlobServiceClient=service_client),
+    }
+    with patch.dict(sys.modules, module_patches):
+        import rohmu.object_storage.azure
+
+    return rohmu.object_storage.azure, get_blob_client_mock
+
+
+@pytest.fixture(name="azure_module")
+def fixture_azure_module(mock_azure_module) -> ModuleType:
+    return mock_azure_module[0]
+
+
+@pytest.fixture(name="get_blob_client")
+def fixture_get_blob_client(mock_azure_module) -> MagicMock:
+    return mock_azure_module[1]
+
+
+def test_store_file_from_disk(azure_module: ModuleType, get_blob_client: MagicMock) -> None:
+    notifier = MagicMock()
+    transfer = azure_module.AzureTransfer(
+        bucket_name="test_bucket",
+        account_name="test_account",
+        account_key="test_key1",
+        notifier=notifier,
+    )
+    test_data = b"test-data"
+    upload_blob = MagicMock()
+    get_blob_client.return_value = MagicMock(upload_blob=upload_blob)
+
+    with NamedTemporaryFile() as tmpfile:
+        tmpfile.write(test_data)
+        tmpfile.flush()
+        transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
+
+    upload_blob.assert_called_once()
+    notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data))
+
+
+def test_store_file_object(azure_module: ModuleType, get_blob_client: MagicMock) -> None:
+    notifier = MagicMock()
+    transfer = azure_module.AzureTransfer(
+        bucket_name="test_bucket",
+        account_name="test_account",
+        account_key="test_key2",
+        notifier=notifier,
+    )
+    test_data = b"test-data-2"
+    file_object = BytesIO(test_data)
+
+    def upload_side_effect(*args, **kwargs):  # pylint: disable=unused-argument
+        if kwargs.get("raw_response_hook"):
+            kwargs["raw_response_hook"](MagicMock(context={"upload_stream_current": len(test_data)}))
+
+    # Size reporting relies on the progress callback from azure client
+    upload_blob = MagicMock(wraps=upload_side_effect)
+    get_blob_client.return_value = MagicMock(upload_blob=upload_blob)
+
+    transfer.store_file_object(key="test_key2", fd=file_object)
+
+    upload_blob.assert_called_once()
+    notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data))

--- a/test/test_object_storage_sftp.py
+++ b/test/test_object_storage_sftp.py
@@ -1,0 +1,55 @@
+"""Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from io import BytesIO
+from rohmu.object_storage.sftp import SFTPTransfer
+from tempfile import NamedTemporaryFile
+from unittest.mock import MagicMock, patch
+
+
+def test_store_file_from_disk() -> None:
+    notifier = MagicMock()
+    with patch("paramiko.Transport") as _, patch("paramiko.SFTPClient") as sftp_client:
+        client = MagicMock()
+        sftp_client.from_transport.return_value = client
+        transfer = SFTPTransfer(
+            server="sftp.example.com",
+            port=2222,
+            username="testuser",
+            password="testpass",
+            notifier=notifier,
+        )
+        test_data = b"test-data"
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(test_data)
+            tmpfile.flush()
+            transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
+
+        client.putfo.assert_called()
+        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data))
+
+
+def test_store_file_object() -> None:
+    notifier = MagicMock()
+    with patch("paramiko.Transport") as _, patch("paramiko.SFTPClient") as sftp_client:
+        client = MagicMock()
+        sftp_client.from_transport.return_value = client
+        transfer = SFTPTransfer(
+            server="sftp.example.com",
+            port=2222,
+            username="testuser",
+            password="testpass",
+            notifier=notifier,
+        )
+        test_data = b"test-data"
+        file_object = BytesIO(test_data)
+
+        # Size reporting relies on the progress callback from paramiko
+        def upload_side_effect(*args, **kwargs):  # pylint: disable=unused-argument
+            if kwargs.get("callback"):
+                kwargs["callback"](len(test_data), len(test_data))
+
+        client.putfo = MagicMock(wraps=upload_side_effect)
+
+        transfer.store_file_object(key="test_key2", fd=file_object)
+
+        client.putfo.assert_called()
+        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data))

--- a/test/test_object_storage_swift.py
+++ b/test/test_object_storage_swift.py
@@ -1,0 +1,57 @@
+"""Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from io import BytesIO
+from tempfile import NamedTemporaryFile
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+import sys
+
+
+@pytest.fixture(scope="module", name="swift_module")
+def fixture_swift_module() -> ModuleType:
+    with patch.dict(sys.modules, {"swiftclient": MagicMock()}):
+        import rohmu.object_storage.swift
+
+    return rohmu.object_storage.swift
+
+
+def test_store_file_from_disk(swift_module: ModuleType) -> None:
+    notifier = MagicMock()
+    connection = MagicMock()
+    swift_module.client.Connection.return_value = connection
+    transfer = swift_module.SwiftTransfer(
+        user="testuser",
+        key="testkey",
+        container_name="test_container",
+        auth_url="http://auth.example.com",
+        notifier=notifier,
+    )
+    test_data = b"test-data"
+    with NamedTemporaryFile() as tmpfile:
+        tmpfile.write(test_data)
+        tmpfile.flush()
+        transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
+
+    connection.put_object.assert_called()
+    notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data))
+
+
+def test_store_file_object(swift_module: ModuleType) -> None:
+    notifier = MagicMock()
+    connection = MagicMock()
+    swift_module.client.Connection.return_value = connection
+    transfer = swift_module.SwiftTransfer(
+        user="testuser",
+        key="testkey",
+        container_name="test_container",
+        auth_url="http://auth.example.com",
+        notifier=notifier,
+    )
+    test_data = b"test-data"
+    file_object = BytesIO(test_data)
+
+    transfer.store_file_object(key="test_key2", fd=file_object, metadata={"Content-Length": len(test_data)})
+
+    connection.put_object.assert_called()
+    notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data))


### PR DESCRIPTION
For Azure, Swift and SFTP object storages, the attempt to get object size for completion notifications was incorrect, calling `os.path.getsize()` with a file-like object, instead of a path.

Given that the object to store may not be a file on disk, that can be seeked or `stat()`ed, we need some other way to obtain the number of bytes.

For these storages, the store call doesn't seem to return the object size in a convenient way, so make use of the progress callback we implement for object storage backends. That gives us the number of bytes transferred, that we can then pass on to notifier.

For tests, start with these three backends that seemed to have been broken by #67. Some libraries used by them are not in our requirements.dev.txt, so settle for mocking those imports.

<!-- All contributors please complete these sections, including maintainers -->
Looks to fix a few storage backends broken by #67, and adds new tests

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

