### PR TITLE
swift: fix iter_key on empty string

### DIFF
--- a/rohmu/object_storage/swift.py
+++ b/rohmu/object_storage/swift.py
@@ -131,7 +131,7 @@ class SwiftTransfer(BaseTransfer):
         return metadata
 
     def iter_key(self, key, *, with_metadata=True, deep=False, include_key=False):
-        path = self.format_key_for_backend(key, trailing_slash=not include_key)
+        path = self.format_key_for_backend(key, remove_slash_prefix=True, trailing_slash=not include_key)
         self.log.debug("Listing path %r", path)
         if not deep:
             kwargs = {"delimiter": "/"}

--- a/test/test_object_storage_swift.py
+++ b/test/test_object_storage_swift.py
@@ -55,3 +55,18 @@ def test_store_file_object(swift_module: ModuleType) -> None:
 
     connection.put_object.assert_called()
     notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data))
+
+
+def test_iter_key_with_empty_key(swift_module: ModuleType) -> None:
+    notifier = MagicMock()
+    connection = MagicMock(get_container=MagicMock(return_value=[None, {}]))
+    swift_module.client.Connection.return_value = connection
+    transfer = swift_module.SwiftTransfer(
+        user="testuser",
+        key="testkey",
+        container_name="test_container",
+        auth_url="http://auth.example.com",
+        notifier=notifier,
+    )
+    list(transfer.iter_key(""))
+    transfer.conn.get_container.assert_called_with("test_container", prefix="", full_listing=True, delimiter="/")


### PR DESCRIPTION
# About this change - What it does

Listing all keys on root level for Swift requires passing `""` as a key.
    
Currently, in swift `iter_key` converts empty key (`""`) to `"/"`, which makes Swift return empty list of results even when there should be results.
    
This change fixes the issue.

# Why this way

Because it is the simpliest way to fix this issue.
