### PR TITLE
Add some unit tests for object storages that were lacking them

### DIFF
--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -310,7 +310,7 @@ class S3Transfer(BaseTransfer):
             self.multipart_upload_file_object(
                 cache_control=cache_control, fp=fp, key=key, metadata=metadata, mimetype=mimetype, size=size
             )
-            self.notifier.object_created(key=key, size=os.path.getsize(filepath))
+            self.notifier.object_created(key=key, size=size)
 
     def multipart_upload_file_object(self, *, cache_control, fp, key, metadata, mimetype, progress_fn=None, size=None):
         path = self.format_key_for_backend(key, remove_slash_prefix=True)

--- a/test/test_object_storage_google.py
+++ b/test/test_object_storage_google.py
@@ -1,0 +1,46 @@
+"""Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from io import BytesIO
+from rohmu.object_storage.google import GoogleTransfer
+from tempfile import NamedTemporaryFile
+from unittest.mock import MagicMock, patch
+
+
+def test_store_file_from_disk() -> None:
+    notifier = MagicMock()
+    with patch("rohmu.object_storage.google.get_credentials") as _, patch(
+        "rohmu.object_storage.google.GoogleTransfer._upload"
+    ) as upload, patch("rohmu.object_storage.google.GoogleTransfer.get_or_create_bucket") as _:
+        transfer = GoogleTransfer(
+            project_id="test-project-id",
+            bucket_name="test-bucket",
+            notifier=notifier,
+        )
+        test_data = b"test-data"
+        upload.return_value = {"size": len(test_data)}  # server reports the size of the uploaded object
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(test_data)
+            tmpfile.flush()
+            transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
+
+        upload.assert_called()
+        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data))
+
+
+def test_store_file_object() -> None:
+    notifier = MagicMock()
+    with patch("rohmu.object_storage.google.get_credentials") as _, patch(
+        "rohmu.object_storage.google.GoogleTransfer._upload"
+    ) as upload, patch("rohmu.object_storage.google.GoogleTransfer.get_or_create_bucket") as _:
+        transfer = GoogleTransfer(
+            project_id="test-project-id",
+            bucket_name="test-bucket",
+            notifier=notifier,
+        )
+        test_data = b"test-data"
+        file_object = BytesIO(test_data)
+        upload.return_value = {"size": len(test_data)}  # server reports the size of the uploaded object
+
+        transfer.store_file_object(key="test_key2", fd=file_object)
+
+        upload.assert_called()
+        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data))

--- a/test/test_object_storage_local.py
+++ b/test/test_object_storage_local.py
@@ -1,0 +1,40 @@
+"""Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from io import BytesIO
+from rohmu.object_storage.local import LocalTransfer
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from unittest.mock import MagicMock
+
+import os
+
+
+def test_store_file_from_disk() -> None:
+    with TemporaryDirectory() as destdir:
+        notifier = MagicMock()
+        transfer = LocalTransfer(
+            directory=destdir,
+            notifier=notifier,
+        )
+        test_data = b"test-data"
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(test_data)
+            tmpfile.flush()
+            transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
+
+        assert open(os.path.join(destdir, "test_key1"), "rb").read() == test_data
+        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data))
+
+
+def test_store_file_object() -> None:
+    with TemporaryDirectory() as destdir:
+        notifier = MagicMock()
+        transfer = LocalTransfer(
+            directory=destdir,
+            notifier=notifier,
+        )
+        test_data = b"test-data-2"
+        file_object = BytesIO(test_data)
+
+        transfer.store_file_object(key="test_key2", fd=file_object)
+
+        assert open(os.path.join(destdir, "test_key2"), "rb").read() == test_data
+        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data))

--- a/test/test_object_storage_s3.py
+++ b/test/test_object_storage_s3.py
@@ -1,0 +1,49 @@
+"""Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from io import BytesIO
+from rohmu.object_storage.s3 import S3Transfer
+from tempfile import NamedTemporaryFile
+from unittest.mock import MagicMock, patch
+
+
+def test_store_file_from_disk() -> None:
+    notifier = MagicMock()
+    with patch("botocore.session.get_session") as get_session:
+        s3_client = MagicMock()
+        create_client = MagicMock(return_value=s3_client)
+        get_session.return_value = MagicMock(create_client=create_client)
+        transfer = S3Transfer(
+            region="test-region",
+            bucket_name="test-bucket",
+            notifier=notifier,
+        )
+        test_data = b"test-data"
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(test_data)
+            tmpfile.flush()
+            transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
+
+        s3_client.put_object.assert_called()
+        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data))
+
+
+def test_store_file_object() -> None:
+    notifier = MagicMock()
+    with patch("botocore.session.get_session") as get_session:
+        s3_client = MagicMock()
+        create_client = MagicMock(return_value=s3_client)
+        get_session.return_value = MagicMock(create_client=create_client)
+        transfer = S3Transfer(
+            region="test-region",
+            bucket_name="test-bucket",
+            notifier=notifier,
+        )
+        test_data = b"test-data"
+        file_object = BytesIO(test_data)
+
+        transfer.store_file_object(key="test_key2", fd=file_object)
+
+        # store_file_object does a multipart upload
+        s3_client.create_multipart_upload.assert_called()
+        s3_client.upload_part.assert_called()
+        s3_client.complete_multipart_upload.assert_called()
+        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data))


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Add some tests for the object storage types that didn't have them yet. so that the recently added object storage notification feature gets better test coverage.

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

