### PR TITLE
pass object metadata also via the http notifier

### DIFF
--- a/rohmu/notifier/http.py
+++ b/rohmu/notifier/http.py
@@ -130,7 +130,7 @@ class BackgroundHTTPNotifier(Notifier):
         self._stop_event.set()
         self._thread.join(_THREAD_JOIN_TIMEOUT)
 
-    def object_created(self, key: str, size: Optional[int]) -> None:
+    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict]) -> None:
         self._queue.put(
             HTTPNotifyJob(
                 self._url,
@@ -140,6 +140,7 @@ class BackgroundHTTPNotifier(Notifier):
                         "key": key,
                         "size": size,
                         "last_modified": datetime.now(tz=timezone.utc).isoformat(),
+                        "metadata": metadata,
                     }
                 ),
             )

--- a/rohmu/notifier/interface.py
+++ b/rohmu/notifier/interface.py
@@ -7,7 +7,7 @@ class Notifier(ABC):
     """This interface allows external code to be notified about object changes."""
 
     @abstractmethod
-    def object_created(self, key: str, size: Optional[int]) -> None:
+    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict]) -> None:
         """Called when an object is created."""
 
     @abstractmethod
@@ -28,9 +28,9 @@ class Notifier(ABC):
         called instead.
         """
 
-    def object_copied(self, key: str, size: Optional[int]) -> None:
+    def object_copied(self, key: str, size: Optional[int], metadata: Optional[dict]) -> None:
         """Called when an object is copied."""
-        self.object_created(key=key, size=size)
+        self.object_created(key=key, size=size, metadata=metadata)
 
     def close(self) -> None:
         """Method used to clean resources of the notifier, if any."""

--- a/rohmu/notifier/logger.py
+++ b/rohmu/notifier/logger.py
@@ -8,7 +8,7 @@ class LoggerNotifier(Notifier):
     def __init__(self, log: Logger) -> None:
         self._log = log
 
-    def object_created(self, key: str, size: Optional[int]) -> None:
+    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict]) -> None:
         self._log.info("Object created key %r size %r", key, size)
 
     def object_deleted(self, key: str) -> None:

--- a/rohmu/notifier/null.py
+++ b/rohmu/notifier/null.py
@@ -9,7 +9,7 @@ class NullNotifier(Notifier):
     Used by default if configuration is missing to avoid None checks
     """
 
-    def object_created(self, key: str, size: Optional[int]) -> None:
+    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict]) -> None:
         pass
 
     def object_deleted(self, key: str) -> None:

--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -122,7 +122,7 @@ class AzureTransfer(BaseTransfer):
             blob_properties = destination_client.get_blob_properties(timeout=timeout)
             copy_props = blob_properties.copy
             if copy_props.status == "success":
-                self.notifier.object_copied(destination_key, size=blob_properties["size"])
+                self.notifier.object_copied(destination_key, size=blob_properties["size"], metadata=metadata)
                 return
             elif copy_props.status == "pending":
                 if time.monotonic() - start < timeout:
@@ -320,7 +320,7 @@ class AzureTransfer(BaseTransfer):
             metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_"),
             overwrite=True,
         )
-        self.notifier.object_created(key=key, size=len(data))
+        self.notifier.object_created(key=key, size=len(data), metadata=metadata)
 
     def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
         if cache_control is not None:
@@ -338,7 +338,7 @@ class AzureTransfer(BaseTransfer):
                 metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_"),
                 overwrite=True,
             )
-            self.notifier.object_created(key=key, size=os.path.getsize(filepath))
+            self.notifier.object_created(key=key, size=os.path.getsize(filepath), metadata=metadata)
 
     def store_file_object(self, key, fd, *, cache_control=None, metadata=None, mimetype=None, upload_progress_fn=None):
         if cache_control is not None:
@@ -372,7 +372,7 @@ class AzureTransfer(BaseTransfer):
                 raw_response_hook=progress_callback,
                 overwrite=True,
             )
-            self.notifier.object_created(key=key, size=notify_size[0])
+            self.notifier.object_created(key=key, size=notify_size[0], metadata=metadata)
         finally:
             if not seekable:
                 if original_tell is not None:

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -225,7 +225,7 @@ class GoogleTransfer(BaseTransfer):
                 sourceObject=source_object,
             )
             result = self._retry_on_reset(request, request.execute)
-            self.notifier.object_copied(key=destination_key, size=int(result["size"]))
+            self.notifier.object_copied(key=destination_key, size=int(result["size"]), metadata=metadata)
 
     def get_metadata_for_key(self, key):
         path = self.format_key_for_backend(key)
@@ -378,7 +378,7 @@ class GoogleTransfer(BaseTransfer):
         data = BytesIO(memstring)
         upload = MediaIoBaseUpload(data, mimetype or "application/octet-stream", chunksize=UPLOAD_CHUNK_SIZE, resumable=True)
         result = self._upload(upload, key, self.sanitize_metadata(metadata), extra_props, cache_control=cache_control)
-        self.notifier.object_created(key=key, size=int(result["size"]))
+        self.notifier.object_created(key=key, size=int(result["size"]), metadata=metadata)
         return result
 
     # pylint: disable=arguments-differ
@@ -396,7 +396,7 @@ class GoogleTransfer(BaseTransfer):
         mimetype = mimetype or "application/octet-stream"
         upload = MediaFileUpload(filepath, mimetype, chunksize=UPLOAD_CHUNK_SIZE, resumable=True)
         result = self._upload(upload, key, self.sanitize_metadata(metadata), extra_props, cache_control=cache_control)
-        self.notifier.object_created(key=key, size=int(result["size"]))
+        self.notifier.object_created(key=key, size=int(result["size"]), metadata=metadata)
         return result
 
     def store_file_object(self, key, fd, *, cache_control=None, metadata=None, mimetype=None, upload_progress_fn=None):
@@ -409,7 +409,7 @@ class GoogleTransfer(BaseTransfer):
             cache_control=cache_control,
             upload_progress_fn=upload_progress_fn,
         )
-        self.notifier.object_created(key=key, size=int(result["size"]))
+        self.notifier.object_created(key=key, size=int(result["size"]), metadata=metadata)
         return result
 
     def get_or_create_bucket(self, bucket_name):

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -43,7 +43,7 @@ class LocalTransfer(BaseTransfer):
             shutil.copy(source_path + ".metadata", destination_path + ".metadata")
         else:
             self._save_metadata(destination_path, metadata)
-        self.notifier.object_copied(key=destination_key, size=os.path.getsize(destination_path))
+        self.notifier.object_copied(key=destination_key, size=os.path.getsize(destination_path), metadata=metadata)
 
     def get_metadata_for_key(self, key):
         source_path = self.format_key_for_backend(key.strip("/"))
@@ -193,7 +193,7 @@ class LocalTransfer(BaseTransfer):
         with open(target_path, "wb") as fp:
             fp.write(memstring)
         self._save_metadata(target_path, metadata)
-        self.notifier.object_created(key=key, size=os.path.getsize(target_path))
+        self.notifier.object_created(key=key, size=os.path.getsize(target_path), metadata=metadata)
 
     def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
         target_path = self.format_key_for_backend(key.strip("/"))
@@ -206,7 +206,7 @@ class LocalTransfer(BaseTransfer):
         os.makedirs(os.path.dirname(target_path), exist_ok=True)
         shutil.copyfile(filepath, target_path)
         self._save_metadata(target_path, metadata)
-        self.notifier.object_created(key=key, size=os.path.getsize(target_path))
+        self.notifier.object_created(key=key, size=os.path.getsize(target_path), metadata=metadata)
 
     def store_file_object(
         self,
@@ -232,7 +232,7 @@ class LocalTransfer(BaseTransfer):
                     upload_progress_fn(bytes_written)
 
         self._save_metadata(target_path, metadata)
-        self.notifier.object_created(key=key, size=os.path.getsize(target_path))
+        self.notifier.object_created(key=key, size=os.path.getsize(target_path), metadata=metadata)
 
 
 def atomic_create_file(file_path):

--- a/rohmu/object_storage/sftp.py
+++ b/rohmu/object_storage/sftp.py
@@ -188,18 +188,18 @@ class SFTPTransfer(BaseTransfer):
         bio = BytesIO(data)
         try:
             self._put_object(key=key, fd=bio, metadata=metadata)
-            self.notifier.object_created(key=key, size=len(data))
+            self.notifier.object_created(key=key, size=len(data), metadata=metadata)
         except OSError as ex:
             raise StorageError(key) from ex
 
     def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
         with open(filepath, "rb") as fh:
             self._put_object(key=key, fd=fh, metadata=metadata)
-            self.notifier.object_created(key=key, size=os.fstat(fh.fileno()).st_size)
+            self.notifier.object_created(key=key, size=os.fstat(fh.fileno()).st_size, metadata=metadata)
 
     def store_file_object(self, key, fd, *, cache_control=None, metadata=None, mimetype=None, upload_progress_fn=None):
         bytes_written = self._put_object(key, fd, metadata=metadata, upload_progress_fn=upload_progress_fn)
-        self.notifier.object_created(key=key, size=bytes_written)
+        self.notifier.object_created(key=key, size=bytes_written, metadata=metadata)
 
     def _put_object(self, key, fd, *, metadata=None, upload_progress_fn=None) -> int:
         target_path = self.format_key_for_backend(key.strip("/"))

--- a/rohmu/object_storage/swift.py
+++ b/rohmu/object_storage/swift.py
@@ -249,7 +249,7 @@ class SwiftTransfer(BaseTransfer):
         metadata_to_send = self._metadata_to_headers(self.sanitize_metadata(metadata))
         data = bytes(memstring)
         self.conn.put_object(self.container_name, path, contents=data, content_type=mimetype, headers=metadata_to_send)
-        self.notifier.object_created(key=key, size=len(data))
+        self.notifier.object_created(key=key, size=len(data), metadata=metadata)
 
     def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
         obsz = os.path.getsize(filepath)
@@ -263,7 +263,7 @@ class SwiftTransfer(BaseTransfer):
                 mimetype=mimetype,
                 content_length=obsz,
             )
-        self.notifier.object_created(key=key, size=obsz)
+        self.notifier.object_created(key=key, size=obsz, metadata=metadata)
 
     def get_or_create_container(self, container_name):
         start_time = time.monotonic()
@@ -288,7 +288,7 @@ class SwiftTransfer(BaseTransfer):
         if metadata:
             headers["X-Fresh-Metadata"] = True
         self.conn.copy_object(self.container_name, source_key, destination=destination_key, headers=headers)
-        self.notifier.object_copied(key=destination_key, size=None)
+        self.notifier.object_copied(key=destination_key, size=None, metadata=metadata)
 
     def store_file_object(self, key, fd, *, cache_control=None, metadata=None, mimetype=None, upload_progress_fn=None):
         metadata = metadata or {}
@@ -304,7 +304,7 @@ class SwiftTransfer(BaseTransfer):
             multipart=True,
             content_length=content_length,
         )
-        self.notifier.object_created(key=key, size=content_length)
+        self.notifier.object_created(key=key, size=content_length, metadata=metadata)
 
     def _store_file_contents(
         self,

--- a/test/notifier/test_http.py
+++ b/test/notifier/test_http.py
@@ -152,7 +152,7 @@ def test_BackgroundHTTPNotifier_target_url_not_available() -> None:
     size = 1
 
     with _make_notifier(url=f"http://localhost:{hopefully_unused_port}/bad/path") as notifier:
-        notifier.object_created(key=key, size=size)
+        notifier.object_created(key=key, size=size, metadata=None)
         # the queue must be consumed by the background thread and the job discarded if the target
         # url is invalid
         _join_queue_with_timeout(notifier._queue, timeout=5.0)
@@ -163,7 +163,7 @@ def test_BackgroundHTTPNotifier_object_create_size_none() -> None:
     size = None
 
     with _create_server_and_configured_notifier(path=f"/{key}") as (notifier, server, post_called):
-        notifier.object_created(key=key, size=size)
+        notifier.object_created(key=key, size=size, metadata=None)
         assert len(post_called) == 0
         server.handle_request()
         assert len(post_called) == 1
@@ -179,7 +179,7 @@ def test_BackgroundHTTPNotifier_object_create() -> None:
     size = 3
 
     with _create_server_and_configured_notifier(path=f"/{key}") as (notifier, server, post_called):
-        notifier.object_created(key=key, size=size)
+        notifier.object_created(key=key, size=size, metadata=None)
         assert len(post_called) == 0
         server.handle_request()
         assert len(post_called) == 1
@@ -221,7 +221,7 @@ def test_BackgroundHTTPNotifier_object_copied() -> None:
     size = 3
 
     with _create_server_and_configured_notifier(path=f"/{key}") as (notifier, server, post_called):
-        notifier.object_copied(key=key, size=size)
+        notifier.object_copied(key=key, size=size, metadata=None)
         assert len(post_called) == 0
         server.handle_request()
         assert len(post_called) == 1

--- a/test/notifier/test_interface.py
+++ b/test/notifier/test_interface.py
@@ -10,7 +10,7 @@ class _TestNotifier(Notifier):
         self.object_deleted_called = 0
         self.tree_deleted_called = 0
 
-    def object_created(self, key: str, size: Optional[int]) -> None:
+    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict]) -> None:
         self.object_created_called += 1
 
     def object_deleted(self, key: str) -> None:
@@ -25,11 +25,11 @@ def test_interface() -> None:
     key = "test_interface"
 
     assert test.object_created_called == 0
-    test.object_created(key=key, size=0)
+    test.object_created(key=key, size=0, metadata=None)
     assert test.object_created_called == 1
 
     assert test.object_created_called == 1
-    test.object_copied(key=key, size=0)
+    test.object_copied(key=key, size=0, metadata=None)
     assert test.object_created_called == 2, "default implementation calls object_created"
 
     assert test.object_deleted_called == 0

--- a/test/notifier/test_logger.py
+++ b/test/notifier/test_logger.py
@@ -12,7 +12,7 @@ def test_logger_notifier_object_created(caplog: LogCaptureFixture) -> None:
 
     with caplog.at_level(logging.DEBUG):
         assert len(caplog.messages) == 0
-        notifier.object_created(key=key, size=size)
+        notifier.object_created(key=key, size=size, metadata=None)
         assert len(caplog.messages) == 1
 
 
@@ -23,7 +23,7 @@ def test_logger_notifier_object_created_size_none(caplog: LogCaptureFixture) -> 
 
     with caplog.at_level(logging.DEBUG):
         assert len(caplog.messages) == 0
-        notifier.object_created(key=key, size=size)
+        notifier.object_created(key=key, size=size, metadata=None)
         assert len(caplog.messages) == 1
 
 

--- a/test/notifier/test_null.py
+++ b/test/notifier/test_null.py
@@ -7,6 +7,6 @@ def test_null_notifier() -> None:
     key = "test_null_notifier"
     size = 2
 
-    notifier.object_created(key=key, size=size)
+    notifier.object_created(key=key, size=size, metadata=None)
     notifier.object_deleted(key=key)
     notifier.tree_deleted(key=key)

--- a/test/test_object_storage_azure.py
+++ b/test/test_object_storage_azure.py
@@ -53,7 +53,7 @@ def test_store_file_from_disk(azure_module: ModuleType, get_blob_client: MagicMo
         transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
 
     upload_blob.assert_called_once()
-    notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data))
+    notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data), metadata=None)
 
 
 def test_store_file_object(azure_module: ModuleType, get_blob_client: MagicMock) -> None:
@@ -78,4 +78,4 @@ def test_store_file_object(azure_module: ModuleType, get_blob_client: MagicMock)
     transfer.store_file_object(key="test_key2", fd=file_object)
 
     upload_blob.assert_called_once()
-    notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data))
+    notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data), metadata=None)

--- a/test/test_object_storage_google.py
+++ b/test/test_object_storage_google.py
@@ -23,7 +23,7 @@ def test_store_file_from_disk() -> None:
             transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
 
         upload.assert_called()
-        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data))
+        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data), metadata=None)
 
 
 def test_store_file_object() -> None:
@@ -43,4 +43,4 @@ def test_store_file_object() -> None:
         transfer.store_file_object(key="test_key2", fd=file_object)
 
         upload.assert_called()
-        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data))
+        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data), metadata=None)

--- a/test/test_object_storage_local.py
+++ b/test/test_object_storage_local.py
@@ -21,7 +21,7 @@ def test_store_file_from_disk() -> None:
             transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
 
         assert open(os.path.join(destdir, "test_key1"), "rb").read() == test_data
-        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data))
+        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data), metadata=None)
 
 
 def test_store_file_object() -> None:
@@ -37,4 +37,4 @@ def test_store_file_object() -> None:
         transfer.store_file_object(key="test_key2", fd=file_object)
 
         assert open(os.path.join(destdir, "test_key2"), "rb").read() == test_data
-        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data))
+        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data), metadata=None)

--- a/test/test_object_storage_s3.py
+++ b/test/test_object_storage_s3.py
@@ -23,7 +23,7 @@ def test_store_file_from_disk() -> None:
             transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
 
         s3_client.put_object.assert_called()
-        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data))
+        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data), metadata=None)
 
 
 def test_store_file_object() -> None:
@@ -46,4 +46,4 @@ def test_store_file_object() -> None:
         s3_client.create_multipart_upload.assert_called()
         s3_client.upload_part.assert_called()
         s3_client.complete_multipart_upload.assert_called()
-        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data))
+        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data), metadata=None)

--- a/test/test_object_storage_sftp.py
+++ b/test/test_object_storage_sftp.py
@@ -24,7 +24,7 @@ def test_store_file_from_disk() -> None:
             transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
 
         client.putfo.assert_called()
-        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data))
+        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data), metadata=None)
 
 
 def test_store_file_object() -> None:
@@ -52,4 +52,4 @@ def test_store_file_object() -> None:
         transfer.store_file_object(key="test_key2", fd=file_object)
 
         client.putfo.assert_called()
-        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data))
+        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data), metadata=None)

--- a/test/test_object_storage_swift.py
+++ b/test/test_object_storage_swift.py
@@ -34,7 +34,7 @@ def test_store_file_from_disk(swift_module: ModuleType) -> None:
         transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
 
     connection.put_object.assert_called()
-    notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data))
+    notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data), metadata=None)
 
 
 def test_store_file_object(swift_module: ModuleType) -> None:
@@ -50,11 +50,11 @@ def test_store_file_object(swift_module: ModuleType) -> None:
     )
     test_data = b"test-data"
     file_object = BytesIO(test_data)
-
-    transfer.store_file_object(key="test_key2", fd=file_object, metadata={"Content-Length": len(test_data)})
+    metadata = {"Content-Length": len(test_data)}
+    transfer.store_file_object(key="test_key2", fd=file_object, metadata=metadata)
 
     connection.put_object.assert_called()
-    notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data))
+    notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data), metadata=metadata)
 
 
 def test_iter_key_with_empty_key(swift_module: ModuleType) -> None:


### PR DESCRIPTION
this helps notification consuming side not have query it if needed.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

