### PR TITLE
Revert usage of atomic_opener in transfer implementations

### DIFF
--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -11,8 +11,6 @@ from ..notifier.interface import Notifier
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.storage.blob import BlobServiceClient, ContentSettings
 from io import BytesIO
-from pathlib import Path
-from rohmu.atomic_opener import atomic_opener
 
 import azure.common
 import logging
@@ -222,7 +220,7 @@ class AzureTransfer(BaseTransfer):
 
         self.log.debug("Starting to fetch the contents of: %r to: %r", path, filepath_to_store_to)
         try:
-            with atomic_opener(Path(filepath_to_store_to), mode="wb") as f:
+            with open(filepath_to_store_to, "wb") as f:
                 container_client = self.conn.get_container_client(self.container_name)
                 container_client.download_blob(path).readinto(f)
         except azure.core.exceptions.ResourceNotFoundError as ex:  # pylint: disable=no-member

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -235,8 +235,18 @@ class LocalTransfer(BaseTransfer):
         self.notifier.object_created(key=key, size=os.path.getsize(target_path), metadata=metadata)
 
 
+@contextlib.contextmanager
 def atomic_create_file(file_path):
-    """
-    Deprecated; use atomic_opener directly.
-    """
-    return atomic_opener(final_path=file_path, mode="w")
+    """Open a temporary file for writing, rename to final name when done"""
+    fd, tmp_file_path = tempfile.mkstemp(
+        prefix=os.path.basename(file_path), dir=os.path.dirname(file_path), suffix=".metadata_tmp"
+    )
+    try:
+        with os.fdopen(fd, "w") as out_file:
+            yield out_file
+
+        os.rename(tmp_file_path, file_path)
+    except Exception:  # pytest: disable=broad-except
+        with contextlib.suppress(Exception):
+            os.unlink(tmp_file_path)
+        raise

--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -8,8 +8,6 @@ See LICENSE for details
 from ..errors import FileNotFoundFromStorageError, InvalidConfigurationError, StorageError
 from ..notifier.interface import Notifier
 from .base import BaseTransfer, get_total_memory, IterKeyItem, KEY_TYPE_OBJECT, KEY_TYPE_PREFIX
-from pathlib import Path
-from rohmu.atomic_opener import atomic_opener
 from typing import Dict, Optional
 
 import botocore.client
@@ -255,7 +253,7 @@ class S3Transfer(BaseTransfer):
             cb(data_read, body_length)
 
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
-        with atomic_opener(Path(filepath_to_store_to), mode="wb") as fh:
+        with open(filepath_to_store_to, "wb") as fh:
             stream, length, metadata = self._get_object_stream(key)
             self._read_object_to_fileobj(fh, stream, length, cb=progress_callback)
         return metadata

--- a/rohmu/object_storage/sftp.py
+++ b/rohmu/object_storage/sftp.py
@@ -5,12 +5,11 @@ Copyright (c) 2016 Ohmu Ltd
 Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/
 See LICENSE for details
 """
+
 from ..errors import FileNotFoundFromStorageError, InvalidConfigurationError, StorageError
 from ..notifier.interface import Notifier
 from .base import BaseTransfer, IterKeyItem, KEY_TYPE_OBJECT, KEY_TYPE_PREFIX
 from io import BytesIO, StringIO
-from pathlib import Path
-from rohmu.atomic_opener import atomic_opener
 from stat import S_ISDIR
 from typing import cast
 
@@ -61,7 +60,7 @@ class SFTPTransfer(BaseTransfer):
         self.log.debug("SFTPTransfer initialized")
 
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
-        with atomic_opener(Path(filepath_to_store_to), mode="wb") as fh:
+        with open(filepath_to_store_to, "wb") as fh:
             return self.get_contents_to_fileobj(key, fh, progress_callback=progress_callback)
 
     def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback=None):

--- a/rohmu/object_storage/swift.py
+++ b/rohmu/object_storage/swift.py
@@ -10,8 +10,6 @@ from ..errors import FileNotFoundFromStorageError
 from ..notifier.interface import Notifier
 from .base import BaseTransfer, IterKeyItem, KEY_TYPE_OBJECT, KEY_TYPE_PREFIX
 from contextlib import suppress
-from pathlib import Path
-from rohmu.atomic_opener import atomic_opener
 from swiftclient import client, exceptions  # pylint: disable=import-error
 
 import logging
@@ -197,8 +195,15 @@ class SwiftTransfer(BaseTransfer):
         self.notifier.object_deleted(key=key)
 
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
-        with atomic_opener(Path(filepath_to_store_to), mode="wb") as fp:
-            return self.get_contents_to_fileobj(key, fp, progress_callback=progress_callback)
+        temp_filepath = "{}~".format(filepath_to_store_to)
+        try:
+            with open(temp_filepath, "wb") as fp:
+                metadata = self.get_contents_to_fileobj(key, fp, progress_callback=progress_callback)
+                os.rename(temp_filepath, filepath_to_store_to)
+        finally:
+            with suppress(FileNotFoundError):
+                os.unlink(temp_filepath)
+        return metadata
 
     def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback=None):
         path = self.format_key_for_backend(key)

--- a/test/test_atomic_opener.py
+++ b/test/test_atomic_opener.py
@@ -14,13 +14,13 @@ def _verify_file_not_created_and_dir_not_polluted(output_file: Path):
 
 def test_error_thrown_if_final_path_parent_doesnt_exist(tmp_path: Path):
     with pytest.raises(IOError):
-        with atomic_opener(tmp_path / "nonexistingdir" / "final_path", mode="w"):
+        with atomic_opener(tmp_path / "nonexistingdir" / "final_path", mode="w") as f:
             pass
 
 
 def test_error_mode_doesnt_contain_write(tmp_path: Path):
     with pytest.raises(ValueError):
-        with atomic_opener(tmp_path, mode="r"):  # type: ignore
+        with atomic_opener(tmp_path, mode="r") as f:  # type: ignore
             pass
 
 

--- a/test/test_atomic_opener.py
+++ b/test/test_atomic_opener.py
@@ -14,13 +14,13 @@ def _verify_file_not_created_and_dir_not_polluted(output_file: Path):
 
 def test_error_thrown_if_final_path_parent_doesnt_exist(tmp_path: Path):
     with pytest.raises(IOError):
-        with atomic_opener(tmp_path / "nonexistingdir" / "final_path", mode="w") as f:
+        with atomic_opener(tmp_path / "nonexistingdir" / "final_path", mode="w"):
             pass
 
 
 def test_error_mode_doesnt_contain_write(tmp_path: Path):
     with pytest.raises(ValueError):
-        with atomic_opener(tmp_path, mode="r") as f:  # type: ignore
+        with atomic_opener(tmp_path, mode="r"):  # type: ignore
             pass
 
 


### PR DESCRIPTION
This reverts commit a9fc9a06526ed8baa80e159724c16589c0c548db and b4861247ea3e5ca364566416d3415f1a535f97dd .

The change is causing issues in some dev environments with some filesystems, and when running pghoard tests as well. Check: https://github.com/aiven/pghoard/pull/557

