### PR TITLE
notfier: bump retry times and backup_off for http notifer

### DIFF
--- a/rohmu/notifier/http.py
+++ b/rohmu/notifier/http.py
@@ -32,8 +32,8 @@ class Operation(Enum):
 
 def _get_requests_session() -> requests.Session:
     retry = requests.adapters.Retry(
-        total=3,
-        backoff_factor=0.5,
+        total=5,
+        backoff_factor=1,
         status_forcelist=[429, 500, 502, 503, 504],
         allowed_methods={"POST"},
     )


### PR DESCRIPTION
this gives the receiving side more time to recover fromr a restart

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

