### PR TITLE
Provide consistent progress metric callbacks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,13 @@ jobs:
     steps:
 
       - id: checkout-code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Do not persist the token during execution of this job.
           persist-credentials: false
 
       - id: prepare-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - id: checkout-code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - id: prepare-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: "3.7"
 

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Main Branch"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           path: main
           ref: main
 
       - name: "Checkout GitHub Pages Branch"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           path: gh-pages

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,6 +4,8 @@ mock
 mypy
 # Same version from pghoard
 pylint>=2.4.3,<=2.7.2
+boto3
+boto3-stubs[essential]
 pylint-quotes
 pytest
 pytest-cov

--- a/rohmu.spec
+++ b/rohmu.spec
@@ -8,6 +8,7 @@ Source0:        rohmu-rpm-src.tar
 Requires:       python3-azure-common
 Requires:       python3-azure-core
 Requires:       python3-azure-storage-blob
+Requires:       python3-boto3
 Requires:       python3-botocore
 Requires:       python3-cryptography >= 0.8
 Requires:       python3-dateutil

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -411,12 +411,12 @@ class GoogleTransfer(BaseTransfer):
         key,
         filepath,
         metadata=None,  # pylint: disable=arguments-differ, unused-variable
-        *,
         multipart=None,
-        extra_props=None,  # pylint: disable=arguments-differ, unused-variable
         cache_control=None,
         mimetype=None,
         progress_fn: ProgressProportionCallbackType = None,
+        *,
+        extra_props=None,  # pylint: disable=arguments-differ, unused-variable
     ):
         size = os.path.getsize(filepath)
         mimetype = mimetype or "application/octet-stream"

--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -16,8 +16,11 @@ from .base import (
     KEY_TYPE_PREFIX,
     ProgressProportionCallbackType,
 )
+from mypy_boto3_s3.client import S3Client
+from mypy_boto3_s3.type_defs import CompletedPartTypeDef
 from typing import Dict, Optional
 
+import boto3
 import botocore.client
 import botocore.config
 import botocore.exceptions
@@ -59,6 +62,8 @@ READ_BLOCK_SIZE = 1024 * 1024 * 1
 
 
 class S3Transfer(BaseTransfer):
+    s3_client: S3Client
+
     def __init__(
         self,
         region,
@@ -79,7 +84,7 @@ class S3Transfer(BaseTransfer):
         aws_session_token: Optional[str] = None,
     ) -> None:
         super().__init__(prefix=prefix, notifier=notifier)
-        botocore_session = botocore.session.get_session()
+        session = boto3.Session()
         self.bucket_name = bucket_name
         self.location = ""
         self.region = region
@@ -93,7 +98,7 @@ class S3Transfer(BaseTransfer):
             if proxy_info:
                 proxy_url = get_proxy_url(proxy_info)
                 custom_config["proxies"] = {"https": proxy_url}
-            self.s3_client = botocore_session.create_client(
+            self.s3_client = session.client(
                 "s3",
                 config=botocore.config.Config(**custom_config),
                 aws_access_key_id=aws_access_key_id,
@@ -120,7 +125,7 @@ class S3Transfer(BaseTransfer):
                 proxies=proxies,
                 **timeouts,
             )
-            self.s3_client = botocore_session.create_client(
+            self.s3_client = session.client(
                 "s3",
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
@@ -351,12 +356,12 @@ class S3Transfer(BaseTransfer):
         start_of_multipart_upload = time.monotonic()
         bytes_sent = 0
 
-        chunks = "Unknown"
+        chunks: int = 1
         if size is not None:
             chunks = math.ceil(size / self.multipart_chunk_size)
         self.log.debug("Starting to upload multipart file: %r, size: %s, chunks: %s", path, size, chunks)
 
-        parts = []
+        parts: list[CompletedPartTypeDef] = []
         part_number = 1
 
         args = {
@@ -373,11 +378,11 @@ class S3Transfer(BaseTransfer):
         if mimetype is not None:
             args["ContentType"] = mimetype
         try:
-            response = self.s3_client.create_multipart_upload(**args)
+            cmu_response = self.s3_client.create_multipart_upload(**args)
         except botocore.exceptions.ClientError as ex:
             raise StorageError("Failed to initiate multipart upload for {}".format(path)) from ex
 
-        mp_id = response["UploadId"]
+        mp_id = cmu_response["UploadId"]
 
         while True:
             data = self._read_bytes(fp, self.multipart_chunk_size)
@@ -389,7 +394,7 @@ class S3Transfer(BaseTransfer):
             while True:
                 attempts -= 1
                 try:
-                    response = self.s3_client.upload_part(
+                    cup_response = self.s3_client.upload_part(
                         Body=data,
                         Bucket=self.bucket_name,
                         Key=path,
@@ -420,7 +425,7 @@ class S3Transfer(BaseTransfer):
                     )
                     parts.append(
                         {
-                            "ETag": response["ETag"],
+                            "ETag": cup_response["ETag"],
                             "PartNumber": part_number,
                         }
                     )


### PR DESCRIPTION
While some methods already support a progress metric being passed to them, some do not. This makes it difficult to transition upstream projects to rely on progress-based metrics and alerting.

This PR enhances `rohmufile` to inject an argument - the number of bytes transmitted - to its callback, while maintaining backwards-compatibility. It also adds progress callback support to `store_file_from_disk`, which previously did not support it, and allows more implementations to invoke the progress callbacks in more situations. (For example, the `s3` backend now provides progress during a multi-part file upload, which is very common)