### PR TITLE
notifier: sanitize metadata before trying to json dump

### DIFF
--- a/rohmu/notifier/http.py
+++ b/rohmu/notifier/http.py
@@ -88,7 +88,7 @@ def initialize_background_thread(
     queue: Queue,
     stop_event: threading.Event,
     stop_event_check_timeout: float = _CHECK_STOP_EVENT_TIMEOUT,
-    session: requests.Session = None,
+    session: Optional[requests.Session] = None,
 ) -> threading.Thread:
     thread_session = session or _get_requests_session()
     thread_args = (thread_session, queue, stop_event, stop_event_check_timeout)
@@ -109,7 +109,7 @@ class BackgroundHTTPNotifier(Notifier):
         self,
         url: str,
         stop_event_check_timeout: float = _CHECK_STOP_EVENT_TIMEOUT,
-        session: requests.Session = None,
+        session: Optional[requests.Session] = None,
     ) -> None:
         self._url = url
         self._queue: "Queue[HTTPNotifyJob]" = Queue()

--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -11,6 +11,7 @@ from ..notifier.interface import Notifier
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.storage.blob import BlobServiceClient, ContentSettings
 from io import BytesIO
+from typing import Optional
 
 import azure.common
 import logging
@@ -60,7 +61,7 @@ class AzureTransfer(BaseTransfer):
         prefix=None,
         azure_cloud=None,
         proxy_info=None,
-        notifier: Notifier = None,
+        notifier: Optional[Notifier] = None,
     ) -> None:
         prefix = "{}".format(prefix.lstrip("/") if prefix else "")
         super().__init__(prefix=prefix, notifier=notifier)

--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -311,14 +311,15 @@ class AzureTransfer(BaseTransfer):
         blob_client = self.conn.get_blob_client(self.container_name, path)
         # Azure's client requires a bytes object
         data = bytes(memstring)
+        sanitized_metadata = self.sanitize_metadata(metadata, replace_hyphen_with="_")
         blob_client.upload_blob(
             data,
             blob_type=BlobType.BlockBlob,
             content_settings=content_settings,
-            metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_"),
+            metadata=sanitized_metadata,
             overwrite=True,
         )
-        self.notifier.object_created(key=key, size=len(data), metadata=metadata)
+        self.notifier.object_created(key=key, size=len(data), metadata=sanitized_metadata)
 
     def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
         if cache_control is not None:
@@ -327,16 +328,17 @@ class AzureTransfer(BaseTransfer):
         content_settings = None
         if mimetype:
             content_settings = ContentSettings(content_type=mimetype)
+        sanitized_metadata = self.sanitize_metadata(metadata, replace_hyphen_with="_")
         with open(filepath, "rb") as data:
             blob_client = self.conn.get_blob_client(self.container_name, path)
             blob_client.upload_blob(
                 data,
                 blob_type=BlobType.BlockBlob,
                 content_settings=content_settings,
-                metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_"),
+                metadata=sanitized_metadata,
                 overwrite=True,
             )
-            self.notifier.object_created(key=key, size=os.path.getsize(filepath), metadata=metadata)
+            self.notifier.object_created(key=key, size=os.path.getsize(filepath), metadata=sanitized_metadata)
 
     def store_file_object(self, key, fd, *, cache_control=None, metadata=None, mimetype=None, upload_progress_fn=None):
         if cache_control is not None:
@@ -360,17 +362,18 @@ class AzureTransfer(BaseTransfer):
         if not seekable:
             original_tell = getattr(fd, "tell", None)
             fd.tell = lambda: None
+        sanitized_metadata = self.sanitize_metadata(metadata, replace_hyphen_with="_")
         try:
             blob_client = self.conn.get_blob_client(self.container_name, path)
             blob_client.upload_blob(
                 fd,
                 blob_type=BlobType.BlockBlob,
                 content_settings=content_settings,
-                metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_"),
+                metadata=sanitized_metadata,
                 raw_response_hook=progress_callback,
                 overwrite=True,
             )
-            self.notifier.object_created(key=key, size=notify_size[0], metadata=metadata)
+            self.notifier.object_created(key=key, size=notify_size[0], metadata=sanitized_metadata)
         finally:
             if not seekable:
                 if original_tell is not None:

--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -9,6 +9,7 @@ from ..errors import StorageError
 from ..notifier.interface import Notifier
 from ..notifier.null import NullNotifier
 from collections import namedtuple
+from typing import Optional
 
 import logging
 import platform
@@ -20,7 +21,7 @@ IterKeyItem = namedtuple("IterKeyItem", ["type", "value"])
 
 
 class BaseTransfer:
-    def __init__(self, prefix, notifier: Notifier = None) -> None:
+    def __init__(self, prefix, notifier: Optional[Notifier] = None) -> None:
         self.log = logging.getLogger(self.__class__.__name__)
         if not prefix:
             prefix = ""

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -386,8 +386,9 @@ class GoogleTransfer(BaseTransfer):
     def store_file_from_memory(self, key, memstring, metadata=None, extra_props=None, cache_control=None, mimetype=None):
         data = BytesIO(memstring)
         upload = MediaIoBaseUpload(data, mimetype or "application/octet-stream", chunksize=UPLOAD_CHUNK_SIZE, resumable=True)
-        result = self._upload(upload, key, self.sanitize_metadata(metadata), extra_props, cache_control=cache_control)
-        self.notifier.object_created(key=key, size=int(result["size"]), metadata=metadata)
+        sanitized_metadata = self.sanitize_metadata(metadata)
+        result = self._upload(upload, key, sanitized_metadata, extra_props, cache_control=cache_control)
+        self.notifier.object_created(key=key, size=int(result["size"]), metadata=sanitized_metadata)
         return result
 
     # pylint: disable=arguments-differ
@@ -404,21 +405,23 @@ class GoogleTransfer(BaseTransfer):
     ):
         mimetype = mimetype or "application/octet-stream"
         upload = MediaFileUpload(filepath, mimetype, chunksize=UPLOAD_CHUNK_SIZE, resumable=True)
-        result = self._upload(upload, key, self.sanitize_metadata(metadata), extra_props, cache_control=cache_control)
-        self.notifier.object_created(key=key, size=int(result["size"]), metadata=metadata)
+        sanitized_metadata = self.sanitize_metadata(metadata)
+        result = self._upload(upload, key, sanitized_metadata, extra_props, cache_control=cache_control)
+        self.notifier.object_created(key=key, size=int(result["size"]), metadata=sanitized_metadata)
         return result
 
     def store_file_object(self, key, fd, *, cache_control=None, metadata=None, mimetype=None, upload_progress_fn=None):
         mimetype = mimetype or "application/octet-stream"
+        sanitized_metadata = self.sanitize_metadata(metadata)
         result = self._upload(
             MediaStreamUpload(fd, chunk_size=UPLOAD_CHUNK_SIZE, mime_type=mimetype, name=key),
             key,
-            self.sanitize_metadata(metadata),
+            sanitized_metadata,
             None,
             cache_control=cache_control,
             upload_progress_fn=upload_progress_fn,
         )
-        self.notifier.object_created(key=key, size=int(result["size"]), metadata=metadata)
+        self.notifier.object_created(key=key, size=int(result["size"]), metadata=sanitized_metadata)
         return result
 
     def get_or_create_bucket(self, bucket_name):

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -19,6 +19,7 @@ from http.client import IncompleteRead
 from io import BytesIO, FileIO
 from oauth2client import GOOGLE_TOKEN_URI
 from oauth2client.client import GoogleCredentials
+from typing import Optional
 
 import codecs
 import errno
@@ -107,7 +108,7 @@ class GoogleTransfer(BaseTransfer):
         credentials=None,
         prefix=None,
         proxy_info=None,
-        notifier: Notifier = None,
+        notifier: Optional[Notifier] = None,
     ) -> None:
         super().__init__(prefix=prefix, notifier=notifier)
         self.project_id = project_id

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -9,6 +9,7 @@ from ..errors import FileNotFoundFromStorageError, LocalFileIsRemoteFileError
 from ..notifier.interface import Notifier
 from .base import BaseTransfer, IterKeyItem, KEY_TYPE_OBJECT, KEY_TYPE_PREFIX
 from io import BytesIO
+from typing import Optional
 
 import contextlib
 import datetime
@@ -25,7 +26,7 @@ class LocalTransfer(BaseTransfer):
         self,
         directory,
         prefix=None,
-        notifier: Notifier = None,
+        notifier: Optional[Notifier] = None,
     ) -> None:
         prefix = os.path.join(directory, (prefix or "").strip("/"))
         super().__init__(prefix=prefix, notifier=notifier)

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -192,7 +192,7 @@ class LocalTransfer(BaseTransfer):
         with open(target_path, "wb") as fp:
             fp.write(memstring)
         self._save_metadata(target_path, metadata)
-        self.notifier.object_created(key=key, size=os.path.getsize(target_path), metadata=metadata)
+        self.notifier.object_created(key=key, size=os.path.getsize(target_path), metadata=self.sanitize_metadata(metadata))
 
     def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
         target_path = self.format_key_for_backend(key.strip("/"))
@@ -205,7 +205,7 @@ class LocalTransfer(BaseTransfer):
         os.makedirs(os.path.dirname(target_path), exist_ok=True)
         shutil.copyfile(filepath, target_path)
         self._save_metadata(target_path, metadata)
-        self.notifier.object_created(key=key, size=os.path.getsize(target_path), metadata=metadata)
+        self.notifier.object_created(key=key, size=os.path.getsize(target_path), metadata=self.sanitize_metadata(metadata))
 
     def store_file_object(
         self,
@@ -231,7 +231,7 @@ class LocalTransfer(BaseTransfer):
                     upload_progress_fn(bytes_written)
 
         self._save_metadata(target_path, metadata)
-        self.notifier.object_created(key=key, size=os.path.getsize(target_path), metadata=metadata)
+        self.notifier.object_created(key=key, size=os.path.getsize(target_path), metadata=self.sanitize_metadata(metadata))
 
 
 @contextlib.contextmanager

--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -67,7 +67,7 @@ class S3Transfer(BaseTransfer):
         proxy_info=None,
         connect_timeout=None,
         read_timeout=None,
-        notifier: Notifier = None,
+        notifier: Optional[Notifier] = None,
     ) -> None:
         super().__init__(prefix=prefix, notifier=notifier)
         botocore_session = botocore.session.get_session()

--- a/rohmu/object_storage/sftp.py
+++ b/rohmu/object_storage/sftp.py
@@ -11,7 +11,7 @@ from ..notifier.interface import Notifier
 from .base import BaseTransfer, IterKeyItem, KEY_TYPE_OBJECT, KEY_TYPE_PREFIX
 from io import BytesIO, StringIO
 from stat import S_ISDIR
-from typing import cast
+from typing import cast, Optional
 
 import datetime
 import json
@@ -30,7 +30,7 @@ class SFTPTransfer(BaseTransfer):
         password=None,
         private_key=None,
         prefix=None,
-        notifier: Notifier = None,
+        notifier: Optional[Notifier] = None,
     ) -> None:
         super().__init__(prefix=prefix, notifier=notifier)
         self.server = server

--- a/rohmu/object_storage/swift.py
+++ b/rohmu/object_storage/swift.py
@@ -11,6 +11,7 @@ from ..notifier.interface import Notifier
 from .base import BaseTransfer, IterKeyItem, KEY_TYPE_OBJECT, KEY_TYPE_PREFIX
 from contextlib import suppress
 from swiftclient import client, exceptions  # pylint: disable=import-error
+from typing import Optional
 
 import logging
 import os
@@ -64,7 +65,7 @@ class SwiftTransfer(BaseTransfer):
         project_domain_name=None,
         service_type=None,
         endpoint_type=None,
-        notifier: Notifier = None,
+        notifier: Optional[Notifier] = None,
     ) -> None:
         prefix = prefix.lstrip("/") if prefix else ""
         super().__init__(prefix=prefix, notifier=notifier)

--- a/rohmu/object_storage/swift.py
+++ b/rohmu/object_storage/swift.py
@@ -251,10 +251,11 @@ class SwiftTransfer(BaseTransfer):
             raise NotImplementedError("SwiftTransfer: cache_control support not implemented")
 
         path = self.format_key_for_backend(key)
-        metadata_to_send = self._metadata_to_headers(self.sanitize_metadata(metadata))
+        sanitized_metadata = self.sanitize_metadata(metadata)
+        metadata_to_send = self._metadata_to_headers(sanitized_metadata)
         data = bytes(memstring)
         self.conn.put_object(self.container_name, path, contents=data, content_type=mimetype, headers=metadata_to_send)
-        self.notifier.object_created(key=key, size=len(data), metadata=metadata)
+        self.notifier.object_created(key=key, size=len(data), metadata=sanitized_metadata)
 
     def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
         obsz = os.path.getsize(filepath)
@@ -268,7 +269,7 @@ class SwiftTransfer(BaseTransfer):
                 mimetype=mimetype,
                 content_length=obsz,
             )
-        self.notifier.object_created(key=key, size=obsz, metadata=metadata)
+        self.notifier.object_created(key=key, size=obsz, metadata=self.sanitize_metadata(metadata))
 
     def get_or_create_container(self, container_name):
         start_time = time.monotonic()
@@ -289,11 +290,12 @@ class SwiftTransfer(BaseTransfer):
     def copy_file(self, *, source_key, destination_key, metadata=None, **_kwargs):
         source_key = self.format_key_for_backend(source_key)
         destination_key = "/".join((self.container_name, self.format_key_for_backend(destination_key)))
-        headers = self._metadata_to_headers(self.sanitize_metadata(metadata))
+        sanitized_metadata = self.sanitize_metadata(metadata)
+        headers = self._metadata_to_headers(sanitized_metadata)
         if metadata:
             headers["X-Fresh-Metadata"] = True
         self.conn.copy_object(self.container_name, source_key, destination=destination_key, headers=headers)
-        self.notifier.object_copied(key=destination_key, size=None, metadata=metadata)
+        self.notifier.object_copied(key=destination_key, size=None, metadata=sanitized_metadata)
 
     def store_file_object(self, key, fd, *, cache_control=None, metadata=None, mimetype=None, upload_progress_fn=None):
         metadata = metadata or {}
@@ -309,7 +311,7 @@ class SwiftTransfer(BaseTransfer):
             multipart=True,
             content_length=content_length,
         )
-        self.notifier.object_created(key=key, size=content_length, metadata=metadata)
+        self.notifier.object_created(key=key, size=content_length, metadata=self.sanitize_metadata(metadata))
 
     def _store_file_contents(
         self,

--- a/test/test_object_storage_azure.py
+++ b/test/test_object_storage_azure.py
@@ -1,4 +1,5 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from datetime import datetime
 from io import BytesIO
 from tempfile import NamedTemporaryFile
 from types import ModuleType
@@ -44,7 +45,7 @@ def test_store_file_from_disk(azure_module: ModuleType, get_blob_client: MagicMo
         notifier=notifier,
     )
     test_data = b"test-data"
-    metadata = {"Content-Length": len(test_data), "some-object": object()}
+    metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
     upload_blob = MagicMock()
     get_blob_client.return_value = MagicMock(upload_blob=upload_blob)
 
@@ -55,7 +56,7 @@ def test_store_file_from_disk(azure_module: ModuleType, get_blob_client: MagicMo
 
     upload_blob.assert_called_once()
     notifier.object_created.assert_called_once_with(
-        key="test_key1", size=len(test_data), metadata=transfer.sanitize_metadata(metadata, replace_hyphen_with="_")
+        key="test_key1", size=len(test_data), metadata={"Content_Length": "9", "some_date": "2022-11-15 18:30:58.486644"}
     )
 
 
@@ -67,8 +68,8 @@ def test_store_file_object(azure_module: ModuleType, get_blob_client: MagicMock)
         account_key="test_key2",
         notifier=notifier,
     )
-    test_data = b"test-data-2"
-    metadata = {"Content-Length": len(test_data), "some-object": object()}
+    test_data = b"test-data"
+    metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
     file_object = BytesIO(test_data)
 
     def upload_side_effect(*args, **kwargs):  # pylint: disable=unused-argument
@@ -83,5 +84,5 @@ def test_store_file_object(azure_module: ModuleType, get_blob_client: MagicMock)
 
     upload_blob.assert_called_once()
     notifier.object_created.assert_called_once_with(
-        key="test_key2", size=len(test_data), metadata=transfer.sanitize_metadata(metadata, replace_hyphen_with="_")
+        key="test_key2", size=len(test_data), metadata={"Content_Length": "9", "some_date": "2022-11-15 18:30:58.486644"}
     )

--- a/test/test_object_storage_google.py
+++ b/test/test_object_storage_google.py
@@ -1,4 +1,5 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from datetime import datetime
 from io import BytesIO
 from rohmu.object_storage.google import GoogleTransfer
 from tempfile import NamedTemporaryFile
@@ -16,7 +17,7 @@ def test_store_file_from_disk() -> None:
             notifier=notifier,
         )
         test_data = b"test-data"
-        metadata = {"Content-Length": len(test_data), "some-object": object()}
+        metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
         upload.return_value = {"size": len(test_data)}  # server reports the size of the uploaded object
         with NamedTemporaryFile() as tmpfile:
             tmpfile.write(test_data)
@@ -25,7 +26,7 @@ def test_store_file_from_disk() -> None:
 
         upload.assert_called()
         notifier.object_created.assert_called_once_with(
-            key="test_key1", size=len(test_data), metadata=transfer.sanitize_metadata(metadata)
+            key="test_key1", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
         )
 
 
@@ -40,7 +41,8 @@ def test_store_file_object() -> None:
             notifier=notifier,
         )
         test_data = b"test-data"
-        metadata = {"Content-Length": len(test_data), "some-object": object()}
+        metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
+
         file_object = BytesIO(test_data)
         upload.return_value = {"size": len(test_data)}  # server reports the size of the uploaded object
 
@@ -48,5 +50,5 @@ def test_store_file_object() -> None:
 
         upload.assert_called()
         notifier.object_created.assert_called_once_with(
-            key="test_key2", size=len(test_data), metadata=transfer.sanitize_metadata(metadata)
+            key="test_key2", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
         )

--- a/test/test_object_storage_local.py
+++ b/test/test_object_storage_local.py
@@ -21,7 +21,7 @@ def test_store_file_from_disk() -> None:
             transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
 
         assert open(os.path.join(destdir, "test_key1"), "rb").read() == test_data
-        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data), metadata=None)
+        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data), metadata={})
 
 
 def test_store_file_object() -> None:
@@ -37,4 +37,4 @@ def test_store_file_object() -> None:
         transfer.store_file_object(key="test_key2", fd=file_object)
 
         assert open(os.path.join(destdir, "test_key2"), "rb").read() == test_data
-        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data), metadata=None)
+        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data), metadata={})

--- a/test/test_object_storage_s3.py
+++ b/test/test_object_storage_s3.py
@@ -1,4 +1,5 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from datetime import datetime
 from io import BytesIO
 from rohmu.object_storage.s3 import S3Transfer
 from tempfile import NamedTemporaryFile
@@ -17,7 +18,7 @@ def test_store_file_from_disk() -> None:
             notifier=notifier,
         )
         test_data = b"test-data"
-        metadata = {"Content-Length": len(test_data), "some-object": object()}
+        metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
         with NamedTemporaryFile() as tmpfile:
             tmpfile.write(test_data)
             tmpfile.flush()
@@ -25,7 +26,7 @@ def test_store_file_from_disk() -> None:
 
         s3_client.put_object.assert_called()
         notifier.object_created.assert_called_once_with(
-            key="test_key1", size=len(test_data), metadata=transfer.sanitize_metadata(metadata)
+            key="test_key1", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
         )
 
 
@@ -43,7 +44,7 @@ def test_store_file_object() -> None:
         test_data = b"test-data"
         file_object = BytesIO(test_data)
 
-        metadata = {"Content-Length": len(test_data), "some-object": object()}
+        metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
         transfer.store_file_object(key="test_key2", fd=file_object, metadata=metadata)
 
         # store_file_object does a multipart upload
@@ -51,5 +52,5 @@ def test_store_file_object() -> None:
         s3_client.upload_part.assert_called()
         s3_client.complete_multipart_upload.assert_called()
         notifier.object_created.assert_called_once_with(
-            key="test_key2", size=len(test_data), metadata=transfer.sanitize_metadata(metadata)
+            key="test_key2", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
         )

--- a/test/test_object_storage_sftp.py
+++ b/test/test_object_storage_sftp.py
@@ -1,4 +1,5 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from datetime import datetime
 from io import BytesIO
 from rohmu.object_storage.sftp import SFTPTransfer
 from tempfile import NamedTemporaryFile
@@ -18,7 +19,7 @@ def test_store_file_from_disk() -> None:
             notifier=notifier,
         )
         test_data = b"test-data"
-        metadata = {"some-object": object()}
+        metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
         with NamedTemporaryFile() as tmpfile:
             tmpfile.write(test_data)
             tmpfile.flush()
@@ -26,7 +27,7 @@ def test_store_file_from_disk() -> None:
 
         client.putfo.assert_called()
         notifier.object_created.assert_called_once_with(
-            key="test_key1", size=len(test_data), metadata=transfer.sanitize_metadata(metadata)
+            key="test_key1", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
         )
 
 
@@ -52,10 +53,10 @@ def test_store_file_object() -> None:
 
         client.putfo = MagicMock(wraps=upload_side_effect)
 
-        metadata = {"some-object": object()}
+        metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
         transfer.store_file_object(key="test_key2", fd=file_object, metadata=metadata)
 
         client.putfo.assert_called()
         notifier.object_created.assert_called_once_with(
-            key="test_key2", size=len(test_data), metadata=transfer.sanitize_metadata(metadata)
+            key="test_key2", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
         )

--- a/test/test_object_storage_sftp.py
+++ b/test/test_object_storage_sftp.py
@@ -18,13 +18,16 @@ def test_store_file_from_disk() -> None:
             notifier=notifier,
         )
         test_data = b"test-data"
+        metadata = {"some-object": object()}
         with NamedTemporaryFile() as tmpfile:
             tmpfile.write(test_data)
             tmpfile.flush()
-            transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
+            transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name, metadata=metadata)
 
         client.putfo.assert_called()
-        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data), metadata=None)
+        notifier.object_created.assert_called_once_with(
+            key="test_key1", size=len(test_data), metadata=transfer.sanitize_metadata(metadata)
+        )
 
 
 def test_store_file_object() -> None:
@@ -49,7 +52,10 @@ def test_store_file_object() -> None:
 
         client.putfo = MagicMock(wraps=upload_side_effect)
 
-        transfer.store_file_object(key="test_key2", fd=file_object)
+        metadata = {"some-object": object()}
+        transfer.store_file_object(key="test_key2", fd=file_object, metadata=metadata)
 
         client.putfo.assert_called()
-        notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data), metadata=None)
+        notifier.object_created.assert_called_once_with(
+            key="test_key2", size=len(test_data), metadata=transfer.sanitize_metadata(metadata)
+        )

--- a/test/test_object_storage_swift.py
+++ b/test/test_object_storage_swift.py
@@ -1,4 +1,5 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from datetime import datetime
 from io import BytesIO
 from tempfile import NamedTemporaryFile
 from types import ModuleType
@@ -28,7 +29,7 @@ def test_store_file_from_disk(swift_module: ModuleType) -> None:
         notifier=notifier,
     )
     test_data = b"test-data"
-    metadata = {"Content-Length": len(test_data), "some-object": object()}
+    metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
     with NamedTemporaryFile() as tmpfile:
         tmpfile.write(test_data)
         tmpfile.flush()
@@ -36,7 +37,7 @@ def test_store_file_from_disk(swift_module: ModuleType) -> None:
 
     connection.put_object.assert_called()
     notifier.object_created.assert_called_once_with(
-        key="test_key1", size=len(test_data), metadata=transfer.sanitize_metadata(metadata)
+        key="test_key1", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
     )
 
 
@@ -53,12 +54,12 @@ def test_store_file_object(swift_module: ModuleType) -> None:
     )
     test_data = b"test-data"
     file_object = BytesIO(test_data)
-    metadata = {"Content-Length": len(test_data), "some-object": object()}
+    metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
     transfer.store_file_object(key="test_key2", fd=file_object, metadata=metadata)
 
     connection.put_object.assert_called()
     notifier.object_created.assert_called_once_with(
-        key="test_key2", size=len(test_data), metadata=transfer.sanitize_metadata(metadata)
+        key="test_key2", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
     )
 
 


### PR DESCRIPTION
this is needed because metdata can contain complex objects like datetime

An easier way to fix this would be to move sanitize_metadata out of baseclass to utils and directly call it from notifer, but in case of azure the hypen(-) in keys needs to be replaced with underscore (_). and notifer has no idea what storage driver was is use and if hyphen replacement should be done.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

