### PR TITLE
tests: verify compatibility with python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.10", "3.9", "3.8", "3.7"]
+        python-version: ["3.11", "3.10", "3.9", "3.8", "3.7"]
 
     steps:
       - id: checkout-code


### PR DESCRIPTION
Now python 3.11 is stable, we should ensure there are no incompatibilities or regressions when using this version.