### PR TITLE
s3: Allow passing AWS session token

### DIFF
--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -68,6 +68,7 @@ class S3Transfer(BaseTransfer):
         connect_timeout=None,
         read_timeout=None,
         notifier: Optional[Notifier] = None,
+        aws_session_token: Optional[str] = None,
     ) -> None:
         super().__init__(prefix=prefix, notifier=notifier)
         botocore_session = botocore.session.get_session()
@@ -89,6 +90,7 @@ class S3Transfer(BaseTransfer):
                 config=botocore.config.Config(**custom_config),
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token,
                 region_name=region,
             )
             if self.region and self.region != "us-east-1":
@@ -114,6 +116,7 @@ class S3Transfer(BaseTransfer):
                 "s3",
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token,
                 config=boto_config,
                 endpoint_url=custom_url,
                 region_name=region,


### PR DESCRIPTION
Session token needs to be provided when using federated user. This allows using temporary tokens with Rohmu instead of permanent user credentials.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Allows using token obtained from GetFederationToken with Rohmu

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

In some cases it is preferred to use temporary tokens instead of
permanent user credentials when interacting with the object storage.
Without being able to set the session token this is not possible.