### PR TITLE
Retry on google's ServerNotFoundError

### DIFF
--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -180,12 +180,22 @@ class GoogleTransfer(BaseTransfer):
         while True:
             try:
                 return action()
-            except (IncompleteRead, HttpError, ssl.SSLEOFError, socket.timeout, OSError, socket.gaierror) as ex:
+            except (
+                IncompleteRead,
+                HttpError,
+                ssl.SSLEOFError,
+                httplib2.ServerNotFoundError,
+                socket.timeout,
+                OSError,
+                socket.gaierror,
+            ) as ex:
                 # Note that socket.timeout and ssl.SSLEOFError inherit from OSError
                 # and the order of handling the errors here needs to be correct
                 if not retries:
                     raise
-                elif isinstance(ex, (IncompleteRead, socket.timeout, ssl.SSLEOFError, BrokenPipeError)):
+                elif isinstance(
+                    ex, (IncompleteRead, socket.timeout, ssl.SSLEOFError, BrokenPipeError, httplib2.ServerNotFoundError)
+                ):
                     pass  # just retry with the same sleep amount
                 elif isinstance(ex, HttpError):
                     # https://cloud.google.com/storage/docs/json_api/v1/status-codes


### PR DESCRIPTION
While interacting with GCP, rohmu retries for a number of failure modes. These do not include ServerNotFoundError, which has been observed to occur from time to time.

Allow the transfer engine to retry upon receiving this exception, instead of propagating the error to the client.
