### PR TITLE
Remove problematic S3 mypy-related imports

### DIFF
--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -345,7 +345,7 @@ class AzureTransfer(BaseTransfer):
             blob_client = self.conn.get_blob_client(self.container_name, path)
             blob_client.upload_blob(
                 data,
-                blob_type=BlobType.BlockBlob,
+                blob_type=BlobType.BlockBlob,  # type: ignore
                 content_settings=content_settings,
                 metadata=sanitized_metadata,
                 overwrite=True,
@@ -390,7 +390,7 @@ class AzureTransfer(BaseTransfer):
             blob_client = self.conn.get_blob_client(self.container_name, path)
             blob_client.upload_blob(
                 fd,
-                blob_type=BlobType.BlockBlob,
+                blob_type=BlobType.BlockBlob,  # type: ignore
                 content_settings=content_settings,
                 metadata=sanitized_metadata,
                 raw_response_hook=progress_callback,

--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -16,8 +16,6 @@ from .base import (
     KEY_TYPE_PREFIX,
     ProgressProportionCallbackType,
 )
-from mypy_boto3_s3.client import S3Client
-from mypy_boto3_s3.type_defs import CompletedPartTypeDef
 from typing import Dict, Optional
 
 import boto3
@@ -62,8 +60,6 @@ READ_BLOCK_SIZE = 1024 * 1024 * 1
 
 
 class S3Transfer(BaseTransfer):
-    s3_client: S3Client
-
     def __init__(
         self,
         region,
@@ -361,7 +357,7 @@ class S3Transfer(BaseTransfer):
             chunks = math.ceil(size / self.multipart_chunk_size)
         self.log.debug("Starting to upload multipart file: %r, size: %s, chunks: %s", path, size, chunks)
 
-        parts: list[CompletedPartTypeDef] = []
+        parts = []
         part_number = 1
 
         args = {
@@ -439,7 +435,7 @@ class S3Transfer(BaseTransfer):
             self.s3_client.complete_multipart_upload(
                 Bucket=self.bucket_name,
                 Key=path,
-                MultipartUpload={"Parts": parts},
+                MultipartUpload={"Parts": parts},  # type: ignore
                 UploadId=mp_id,
             )
         except botocore.exceptions.ClientError as ex:


### PR DESCRIPTION
Two imports added an additional dependency to rohmu which is not justified. 

While type-checking is very good practice in general, requiring extra downstream packages should not be required for a minor/point release.
