### PR TITLE
Fix the pypi publisher

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -21,6 +21,9 @@ jobs:
       with:
         python-version: "3.7"
 
+    - name: Ensure tags are properly synced
+      run: git fetch --tags --force
+
     - name: Install pypa/build
       run: >-
         python -m pip install build --user


### PR DESCRIPTION
Using the current version of github's checkout action, tags are not properly synced, even when `fetch-depth: 0` is present.

Explicitly fetch the tag references to ensure the annotated tag check succeeds. Without this change, the object type of the reference is simply `commit`, and not `tag`.
