### PR TITLE
Skip file when key is not found in s3.

### DIFF
--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -230,7 +230,10 @@ class S3Transfer(BaseTransfer[Config]):
 
             for item in response.get("Contents", []):
                 if with_metadata:
-                    metadata = {k.lower(): v for k, v in self._metadata_for_key(item["Key"]).items()}
+                    try:
+                        metadata = {k.lower(): v for k, v in self._metadata_for_key(item["Key"]).items()}
+                    except FileNotFoundFromStorageError:
+                        continue
                 else:
                     metadata = None
                 name = self.format_key_from_backend(item["Key"])


### PR DESCRIPTION
There are cases where the list_objects_v2 api returns objects that are not actually present in s3. This cause an error to happen. We should skip these "files"

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
Skip file that fail the head_object api

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

