### PR TITLE
improve google stats reporting

### DIFF
--- a/test/test_object_storage_google.py
+++ b/test/test_object_storage_google.py
@@ -1,16 +1,20 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from contextlib import ExitStack
 from datetime import datetime
+from googleapiclient.http import MediaUploadProgress
 from io import BytesIO
-from rohmu.object_storage.google import GoogleTransfer
+from rohmu.common.models import StorageOperation
+from rohmu.object_storage.google import GoogleTransfer, Reporter
 from tempfile import NamedTemporaryFile
-from unittest.mock import MagicMock, patch
+from unittest.mock import call, MagicMock, patch
 
 
 def test_store_file_from_memory() -> None:
     notifier = MagicMock()
-    with patch("rohmu.object_storage.google.get_credentials") as _, patch(
-        "rohmu.object_storage.google.GoogleTransfer._upload"
-    ) as upload, patch("rohmu.object_storage.google.GoogleTransfer.get_or_create_bucket") as _:
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer.get_or_create_bucket"))
+        upload = stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._upload"))
         transfer = GoogleTransfer(
             project_id="test-project-id",
             bucket_name="test-bucket",
@@ -29,9 +33,11 @@ def test_store_file_from_memory() -> None:
 
 def test_store_file_from_disk() -> None:
     notifier = MagicMock()
-    with patch("rohmu.object_storage.google.get_credentials") as _, patch(
-        "rohmu.object_storage.google.GoogleTransfer._upload"
-    ) as upload, patch("rohmu.object_storage.google.GoogleTransfer.get_or_create_bucket") as _:
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer.get_or_create_bucket"))
+        upload = stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._upload"))
+
         transfer = GoogleTransfer(
             project_id="test-project-id",
             bucket_name="test-bucket",
@@ -53,9 +59,10 @@ def test_store_file_from_disk() -> None:
 
 def test_store_file_object() -> None:
     notifier = MagicMock()
-    with patch("rohmu.object_storage.google.get_credentials") as _, patch(
-        "rohmu.object_storage.google.GoogleTransfer._upload"
-    ) as upload, patch("rohmu.object_storage.google.GoogleTransfer.get_or_create_bucket") as _:
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer.get_or_create_bucket"))
+        upload = stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._upload"))
         transfer = GoogleTransfer(
             project_id="test-project-id",
             bucket_name="test-bucket",
@@ -72,4 +79,44 @@ def test_store_file_object() -> None:
         upload.assert_called()
         notifier.object_created.assert_called_once_with(
             key="test_key2", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
+        )
+
+
+def test_upload_size_unknown_to_reporter() -> None:
+    notifier = MagicMock()
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer.get_or_create_bucket"))
+        mock_retry = stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._retry_on_reset"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer._object_client"))
+        mock_operation = stack.enter_context(patch("rohmu.common.statsd.StatsClient.operation"))
+        transfer = GoogleTransfer(
+            project_id="test-project-id",
+            bucket_name="test-bucket",
+            notifier=notifier,
+        )
+
+        counts = [1, 5, 994]
+        mock_retry.side_effect = [
+            (MediaUploadProgress(counts[0], -1), None),
+            (MediaUploadProgress(counts[1], -1), None),
+            (None, {"size": sum(counts)}),
+        ]
+
+        # pylint: disable=protected-access
+        transfer._upload(
+            upload=MagicMock(),
+            key="testkey",
+            metadata={},
+            extra_props=None,
+            cache_control=None,
+            reporter=Reporter(StorageOperation.store_file_object),
+        )
+        assert mock_operation.call_count == 3
+        mock_operation.assert_has_calls(
+            [
+                call(operation=StorageOperation.store_file_object, size=1),
+                call(operation=StorageOperation.store_file_object, size=4),
+                call(operation=StorageOperation.store_file_object, size=995),
+            ]
         )


### PR DESCRIPTION
somestimes these files are really small (<1MB) sometimes just a few bytes. These get reported as 5MB over even more.

with these (stored_file_from_memory, store_file_from_string) calls it is trivial to get the actual size of data, this helps steer not too far away from the actual sizes.

this might lead to undercounting in case of retries but with such small sizes this should be fine

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

