### PR TITLE
object_storage: API + operation changes

### DIFF
--- a/rohmu/common/models.py
+++ b/rohmu/common/models.py
@@ -13,22 +13,20 @@ class StorageOperation(str, enum.Enum):
     iter_key = "iter_key"
     copy_file = "copy_file"
     delete_key = "delete_key"
-    get_contents_to_string = "get_contents_to_string"
-    get_contents_to_file = "get_contents_to_file"
-    get_contents_to_fileobj = "get_contents_to_fileobj"
+    get_file = "get_file"
     get_file_size = "get_file_size"
     get_metadata_for_key = "get_metadata_for_key"
     list_path = "list_path"
     list_iter = "list_iter"
-    store_file_from_memory = "store_file_from_memory"
-    store_multipart_chunk_from_memory = "store_multipart_chunk_from_memory"
-    store_file_from_disk = "store_file_from_disk"
-    store_file_object = "store_file_object"
+    store_file = "store_file"
     metadata_for_key = "metadata_for_key"
-    create_multipart_upload = "create_multipart_upload"
-    multipart_complete = "multipart_complete"
     head_request = "head_request"
     create_bucket = "create_bucket"
+
+    # These are S3-only but their use (and especially failures) are interesting
+    create_multipart_upload = "create_multipart_upload"
+    multipart_aborted = "multipart_aborted"
+    multipart_complete = "multipart_complete"
 
     def __str__(self):
         return str(self.value)

--- a/rohmu/common/statsd.py
+++ b/rohmu/common/statsd.py
@@ -98,12 +98,11 @@ class StatsClient:
         all_tags.update(tags or {})
         self.increase("exception", tags=all_tags)
 
-    def operation(self, operation, size: Union[None, int, float] = None):
+    def operation(self, operation, *, count: int = 1, size: Union[int, None] = None):
         tags: Tags = {"operation": self._operation_map.get(str(operation), str(operation))}
-        if size is None:
-            self.increase("rohmu_operation", tags=tags)
-        else:
-            self.gauge(metric="rohmu_operation", value=size, tags=tags)
+        self.increase("rohmu_operation_count", tags=tags, inc_value=count)
+        if size is not None:
+            self.increase("rohmu_operation_size", tags=tags, inc_value=size)
 
     def _send(self, metric: str, metric_type: bytes, value: Union[int, float], tags: Optional[Tags]) -> None:
         if not self._enabled:

--- a/rohmu/rohmufile.py
+++ b/rohmu/rohmufile.py
@@ -147,7 +147,6 @@ def write_file(
         compression_level=compression_level,
         rsa_public_key=rsa_public_key,
     ) as fp_out:
-
         header_block = True
         while True:
             input_data = input_obj.read(IO_BLOCK_SIZE)

--- a/test/test_object_storage_google.py
+++ b/test/test_object_storage_google.py
@@ -110,13 +110,13 @@ def test_upload_size_unknown_to_reporter() -> None:
             metadata={},
             extra_props=None,
             cache_control=None,
-            reporter=Reporter(StorageOperation.store_file_object),
+            reporter=Reporter(StorageOperation.store_file),
         )
         assert mock_operation.call_count == 3
         mock_operation.assert_has_calls(
             [
-                call(operation=StorageOperation.store_file_object, size=1),
-                call(operation=StorageOperation.store_file_object, size=4),
-                call(operation=StorageOperation.store_file_object, size=995),
+                call(operation=StorageOperation.store_file, size=1),
+                call(operation=StorageOperation.store_file, size=4),
+                call(operation=StorageOperation.store_file, size=995),
             ]
         )

--- a/test/test_object_storage_local.py
+++ b/test/test_object_storage_local.py
@@ -21,7 +21,9 @@ def test_store_file_from_disk() -> None:
             transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
 
         assert open(os.path.join(destdir, "test_key1"), "rb").read() == test_data
-        notifier.object_created.assert_called_once_with(key="test_key1", size=len(test_data), metadata={})
+        notifier.object_created.assert_called_once_with(
+            key="test_key1", size=len(test_data), metadata={"Content-Length": "9"}
+        )
 
 
 def test_store_file_object() -> None:

--- a/test/test_object_storage_s3.py
+++ b/test/test_object_storage_s3.py
@@ -6,6 +6,8 @@ from rohmu.object_storage.s3 import S3Transfer
 from tempfile import NamedTemporaryFile
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 def test_store_file_from_disk() -> None:
     notifier = MagicMock()
@@ -31,7 +33,8 @@ def test_store_file_from_disk() -> None:
         )
 
 
-def test_store_file_object() -> None:
+@pytest.mark.parametrize("multipart", [False, None, True])
+def test_store_file_object(multipart) -> None:
     notifier = MagicMock()
     with patch("botocore.session.get_session") as get_session:
         s3_client = MagicMock()
@@ -46,15 +49,28 @@ def test_store_file_object() -> None:
         file_object = BytesIO(test_data)
 
         metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
-        transfer.store_file_object(key="test_key2", fd=file_object, metadata=metadata)
+        transfer.store_file_object(key="test_key2", fd=file_object, metadata=metadata, multipart=multipart)
 
-        # store_file_object does a multipart upload
-        s3_client.create_multipart_upload.assert_called()
-        s3_client.upload_part.assert_called()
-        s3_client.complete_multipart_upload.assert_called()
-        notifier.object_created.assert_called_once_with(
-            key="test_key2", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
-        )
+        if multipart is True:
+            # store_file_object does a multipart upload
+            # (if explicitly requested)
+            s3_client.create_multipart_upload.assert_called()
+            s3_client.upload_part.assert_called()
+            s3_client.complete_multipart_upload.assert_called()
+            notifier.object_created.assert_called_once_with(
+                key="test_key2",
+                size=len(test_data),
+                metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"},
+            )
+        else:
+            # size was known and it was small enough so default of
+            # True won't be used in None case
+            s3_client.put_object.assert_called()
+            notifier.object_created.assert_called_once_with(
+                key="test_key2",
+                size=len(test_data),
+                metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"},
+            )
 
 
 @patch("rohmu.object_storage.base.StatsClient.operation")

--- a/test/test_object_storage_sftp.py
+++ b/test/test_object_storage_sftp.py
@@ -9,7 +9,19 @@ from unittest.mock import MagicMock, patch
 def test_store_file_from_disk() -> None:
     notifier = MagicMock()
     with patch("paramiko.Transport") as _, patch("paramiko.SFTPClient") as sftp_client:
+
+        def _putfo():
+            return 42
+
         client = MagicMock()
+
+        # Size reporting relies on the progress callback from paramiko
+        def upload_side_effect(*args, **kwargs):  # pylint: disable=unused-argument
+            if kwargs.get("callback"):
+                kwargs["callback"](len(test_data), len(test_data))
+
+        client.putfo = MagicMock(wraps=upload_side_effect)
+
         sftp_client.from_transport.return_value = client
         transfer = SFTPTransfer(
             server="sftp.example.com",

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -5,6 +5,9 @@ from rohmu import errors
 
 import pytest
 
+DUMMY_CONTENT = b"dummy"
+DUMMY_METADATA = {"Content-Length": str(len(DUMMY_CONTENT))}
+
 
 @pytest.mark.parametrize("transfer", ["local_transfer"])
 def test_nonexistent(transfer, request):
@@ -28,32 +31,40 @@ def test_basic_upload(transfer, tmp_path, request):
     scratch = tmp_path / "scratch"
     scratch.mkdir()
     transfer = request.getfixturevalue(transfer)
-    transfer.store_file_from_memory("x1", b"dummy", {"k": "v"})
-    assert transfer.get_contents_to_string("x1") == (b"dummy", {"k": "v"})
+    sent_metadata = {"k": "v"}
+    metadata = DUMMY_METADATA.copy()
+    metadata.update(sent_metadata)
+    transfer.store_file_from_memory("x1", DUMMY_CONTENT, sent_metadata)
+
+    assert transfer.get_contents_to_string("x1") == (DUMMY_CONTENT, metadata)
     # Same thing, but with a key looking like a directory
-    transfer.store_file_from_memory("NONEXISTENT-DIR/x1", b"dummy", None)
-    assert transfer.get_contents_to_string("NONEXISTENT-DIR/x1") == (b"dummy", {})
+    transfer.store_file_from_memory("NONEXISTENT-DIR/x1", DUMMY_CONTENT, None)
+    assert transfer.get_contents_to_string("NONEXISTENT-DIR/x1") == (DUMMY_CONTENT, DUMMY_METADATA)
 
     # Same thing, but from disk now
     dummy_file = scratch / "a"
     with open(dummy_file, "wb") as fp:
-        fp.write(b"dummy")
+        fp.write(DUMMY_CONTENT)
     transfer.store_file_from_disk("test1/x1", dummy_file, None)
     out = BytesIO()
 
-    assert transfer.get_contents_to_fileobj("test1/x1", out) == {}
-    assert out.getvalue() == b"dummy"
+    assert transfer.get_contents_to_fileobj("test1/x1", out) == DUMMY_METADATA
+    assert out.getvalue() == DUMMY_CONTENT
 
 
 @pytest.mark.parametrize("transfer", ["local_transfer"])
 def test_copy(transfer, request):
     transfer = request.getfixturevalue(transfer)
-    transfer.store_file_from_memory("dummy", b"dummy", {"k": "v"})
+    sent_metadata = {"k": "v"}
+    metadata = DUMMY_METADATA.copy()
+    metadata.update(sent_metadata)
+    transfer.store_file_from_memory("dummy", DUMMY_CONTENT, sent_metadata)
     transfer.copy_file(source_key="dummy", destination_key="dummy_copy")
-    assert transfer.get_contents_to_string("dummy_copy") == (b"dummy", {"k": "v"})
+    assert transfer.get_contents_to_string("dummy_copy") == (DUMMY_CONTENT, metadata)
+
     # Same thing, but with different metadata
     transfer.copy_file(source_key="dummy", destination_key="dummy_copy_metadata", metadata={"new_k": "new_v"})
-    assert transfer.get_contents_to_string("dummy_copy_metadata") == (b"dummy", {"new_k": "new_v"})
+    assert transfer.get_contents_to_string("dummy_copy_metadata") == (DUMMY_CONTENT, {"new_k": "new_v"})
 
 
 @pytest.mark.parametrize("transfer", ["local_transfer"])
@@ -62,16 +73,19 @@ def test_list(transfer, request):
     assert transfer.list_path("") == []
 
     # Test with a single file at root
-    transfer.store_file_from_memory("dummy", b"dummy", metadata={"k": "v"})
+    sent_metadata = {"k": "v"}
+    metadata = DUMMY_METADATA.copy()
+    metadata.update(sent_metadata)
+    transfer.store_file_from_memory("dummy", DUMMY_CONTENT, metadata=sent_metadata)
     file_list = transfer.list_path("")
     assert len(file_list) == 1
     assert file_list[0]["name"] == "dummy"
-    assert file_list[0]["metadata"] == {"k": "v"}
+    assert file_list[0]["metadata"] == metadata
     assert file_list[0]["size"] == len("dummy")
     assert isinstance(file_list[0]["last_modified"], datetime)
 
     # Test with a "subdirectory"
-    transfer.store_file_from_memory("dummydir/dummy", b"dummy", metadata={"k": "v"})
+    transfer.store_file_from_memory("dummydir/dummy", DUMMY_CONTENT, metadata=sent_metadata)
     assert len(transfer.list_path("")) == 1
     assert set(transfer.iter_prefixes("")) == {"dummydir"}
     assert len(transfer.list_path("dummydir")) == 1


### PR DESCRIPTION
- Add get_contents_to_file/string to base class

  (No API change, just implementation simpliciy)

  Ultimately only get_contents_to_fileobj is the interesting one (if we don't implement proper parallel multipart download anyway), and the other two can just use that.

- Add store_file_from_memory, store_file_from_disk to base class

  NOTE: Backward incompatible API change - require keyword arguments also in store_file_from_disk (all Aiven code is fine with it, and we want this going forward)

  NOTE: Handling of 'metadata' varied by functions (in some it was keyword argument, in others not); made it non-keyword third argument in all 3 store variants. (This is backwards compatible, as restrictions were just loosened.)

- operation tracking changes/fixes

  - documented the operations somewhat

  - added multipart abort

  - simplified the list too; we don't really care about the type of get_file that is used (for example); also storing multipart chunks on S3 is just implementation detail and part of store_file API call

  - change operation so that it has both count and size metric (size one is populated only for metrics supplied with size)

  - use increase for both, the old gauge for size dropped data if there was more than one entry per metrics interval

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
This fixes some errors in statsd reporting, and cleans the API implementation quite a bit (while mostly being backwards compatible).

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

There was internal demand for statsd operation reporting fixes, and the API cleanup seemed like good idea at same time (most of providers are still not supported for statsd stuff, but it can be done easier after this).