### PR TITLE
Fix S3 delete_keys and add typing

### DIFF
--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -217,7 +217,7 @@ class AzureTransfer(BaseTransfer[Config]):
                     },
                 )
 
-    def delete_key(self, key):
+    def delete_key(self, key: str) -> None:
         path = self.format_key_for_backend(key, remove_slash_prefix=True)
         self.log.debug("Deleting key: %r", path)
         try:

--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -13,7 +13,7 @@ from ..notifier.null import NullNotifier
 from collections import namedtuple
 from contextlib import suppress
 from io import BytesIO
-from typing import Callable, Generic, Optional, Type, TypeVar, Union
+from typing import Callable, Collection, Generic, Optional, Type, TypeVar, Union
 
 import logging
 import os
@@ -131,10 +131,10 @@ class BaseTransfer(Generic[StorageModelT]):
             raise StorageError("Key {!r} does not start with expected prefix {!r}".format(key, self.prefix))
         return key[len(self.prefix) :]
 
-    def delete_key(self, key):
+    def delete_key(self, key: str) -> None:
         raise NotImplementedError
 
-    def delete_keys(self, keys):
+    def delete_keys(self, keys: Collection[str]) -> None:
         """Delete specified keys"""
         for key in keys:
             self.delete_key(key)

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -366,7 +366,7 @@ class GoogleTransfer(BaseTransfer[Config]):
                 else:
                     raise NotImplementedError(property_name)
 
-    def delete_key(self, key):
+    def delete_key(self, key: str) -> None:
         path = self.format_key_for_backend(key)
         self.log.debug("Deleting key: %r", path)
         with self._object_client(not_found=path) as clob:

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -72,7 +72,7 @@ class LocalTransfer(BaseTransfer[Config]):
         except FileNotFoundError:
             raise FileNotFoundFromStorageError(key)
 
-    def delete_key(self, key):
+    def delete_key(self, key: str) -> None:
         self.log.debug("Deleting key: %r", key)
         target_path = self.format_key_for_backend(key.strip("/"))
         if not os.path.exists(target_path):

--- a/rohmu/object_storage/sftp.py
+++ b/rohmu/object_storage/sftp.py
@@ -182,7 +182,7 @@ class SFTPTransfer(BaseTransfer[Config]):
     def copy_file(self, *, source_key, destination_key, metadata=None, **_kwargs):
         raise NotImplementedError
 
-    def delete_key(self, key):
+    def delete_key(self, key: str) -> None:
         target_path = self.format_key_for_backend(key.strip("/"))
         self.log.info("Removing path: %r", target_path)
 

--- a/rohmu/object_storage/swift.py
+++ b/rohmu/object_storage/swift.py
@@ -213,7 +213,7 @@ class SwiftTransfer(BaseTransfer[Config]):
                 with suppress(FileNotFoundFromStorageError):
                     self._delete_object_plain(item["name"])
 
-    def delete_key(self, key):
+    def delete_key(self, key: str) -> None:
         path = self.format_key_for_backend(key)
         self.log.debug("Deleting key: %r", path)
         try:


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
Fixes a bug introduced in https://github.com/aiven/rohmu/pull/101

<!-- Provide the issue number below if it exists. -->
As it turns out, delete_keys did not really work correctly (and therefore broke also delete_tree). No mypy or test coverage unfortunately. Added mypy coverage, and it is tested elsewhere that the code actually works (but teardown failures were ignored during previous PR work).


# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

While adding proper tests would have been nice too, adding typing + testing elsewhere is hopefully sufficient for now (we have to solve the test credential handling problem first).