### PR TITLE
Fix S3 delete_keys harder

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -9,6 +9,7 @@ boto3-stubs[essential]
 pylint-quotes
 pytest
 pytest-cov
+pytest-mock
 # Same version from pghoard
 isort==5.10.1
 types-python-dateutil

--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -207,7 +207,10 @@ class S3Transfer(BaseTransfer[Config]):
 
     def delete_keys(self, keys: Collection[str]) -> None:
         self.stats.operation(StorageOperation.delete_key, count=len(keys))
-        self.s3_client.delete_objects(Bucket=self.bucket_name, Delete={"Objects": [{"Key": key} for key in keys]})
+        self.s3_client.delete_objects(
+            Bucket=self.bucket_name,
+            Delete={"Objects": [{"Key": self.format_key_for_backend(key, remove_slash_prefix=True)} for key in keys]},
+        )
         # Note: `tree_deleted` is not used here because the operation on S3 is not atomic, i.e.
         # it is possible for a new object to be created after `list_objects` above
         for key in keys:

--- a/test/test_object_storage_s3.py
+++ b/test/test_object_storage_s3.py
@@ -1,88 +1,105 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from dataclasses import dataclass
 from datetime import datetime
 from io import BytesIO
 from rohmu.common.models import StorageOperation
 from rohmu.object_storage.s3 import S3Transfer
 from tempfile import NamedTemporaryFile
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 
-def test_store_file_from_disk() -> None:
-    notifier = MagicMock()
-    with patch("botocore.session.get_session") as get_session:
-        s3_client = MagicMock()
-        create_client = MagicMock(return_value=s3_client)
-        get_session.return_value = MagicMock(create_client=create_client)
-        transfer = S3Transfer(
-            region="test-region",
-            bucket_name="test-bucket",
-            notifier=notifier,
-        )
-        test_data = b"test-data"
-        metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
-        with NamedTemporaryFile() as tmpfile:
-            tmpfile.write(test_data)
-            tmpfile.flush()
-            transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name, metadata=metadata)
+@dataclass
+class S3Infra:
+    notifier: MagicMock
+    operation: MagicMock
+    s3_client: MagicMock
+    transfer: S3Transfer
 
-        s3_client.put_object.assert_called()
-        notifier.object_created.assert_called_once_with(
-            key="test_key1", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
-        )
+
+@pytest.fixture(name="infra")
+def fixture_infra(mocker):
+    notifier = MagicMock()
+    get_session = mocker.patch("botocore.session.get_session")
+    s3_client = MagicMock()
+    create_client = MagicMock(return_value=s3_client)
+    get_session.return_value = MagicMock(create_client=create_client)
+    operation = mocker.patch("rohmu.object_storage.base.StatsClient.operation")
+    transfer = S3Transfer(
+        region="test-region",
+        bucket_name="test-bucket",
+        notifier=notifier,
+        prefix="test-prefix",
+    )
+    yield S3Infra(notifier, operation, s3_client, transfer)
+
+
+def test_store_file_from_disk(infra) -> None:
+    test_data = b"test-data"
+    metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
+    with NamedTemporaryFile() as tmpfile:
+        tmpfile.write(test_data)
+        tmpfile.flush()
+        infra.transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name, metadata=metadata)
+
+    infra.s3_client.put_object.assert_called_once_with(
+        Bucket="test-bucket",
+        Body=b"test-data",
+        Key="test-prefix/test_key1",
+        Metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"},
+    )
+    infra.notifier.object_created.assert_called_once_with(
+        key="test_key1", size=len(test_data), metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"}
+    )
 
 
 @pytest.mark.parametrize("multipart", [False, None, True])
-def test_store_file_object(multipart) -> None:
-    notifier = MagicMock()
-    with patch("botocore.session.get_session") as get_session:
-        s3_client = MagicMock()
-        create_client = MagicMock(return_value=s3_client)
-        get_session.return_value = MagicMock(create_client=create_client)
-        transfer = S3Transfer(
-            region="test-region",
-            bucket_name="test-bucket",
-            notifier=notifier,
+def test_store_file_object(infra, multipart) -> None:
+    test_data = b"test-data"
+    file_object = BytesIO(test_data)
+
+    metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
+    infra.transfer.store_file_object(key="test_key2", fd=file_object, metadata=metadata, multipart=multipart)
+
+    notifier = infra.notifier
+    s3_client = infra.s3_client
+
+    if multipart is True:
+        # store_file_object does a multipart upload
+        # (if explicitly requested)
+        s3_client.create_multipart_upload.assert_called()
+        s3_client.upload_part.assert_called()
+        s3_client.complete_multipart_upload.assert_called()
+        notifier.object_created.assert_called_once_with(
+            key="test_key2",
+            size=len(test_data),
+            metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"},
         )
-        test_data = b"test-data"
-        file_object = BytesIO(test_data)
-
-        metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
-        transfer.store_file_object(key="test_key2", fd=file_object, metadata=metadata, multipart=multipart)
-
-        if multipart is True:
-            # store_file_object does a multipart upload
-            # (if explicitly requested)
-            s3_client.create_multipart_upload.assert_called()
-            s3_client.upload_part.assert_called()
-            s3_client.complete_multipart_upload.assert_called()
-            notifier.object_created.assert_called_once_with(
-                key="test_key2",
-                size=len(test_data),
-                metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"},
-            )
-        else:
-            # size was known and it was small enough so default of
-            # True won't be used in None case
-            s3_client.put_object.assert_called()
-            notifier.object_created.assert_called_once_with(
-                key="test_key2",
-                size=len(test_data),
-                metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"},
-            )
-
-
-@patch("rohmu.object_storage.base.StatsClient.operation")
-def test_operations_reporting(mock_operation) -> None:
-    notifier = MagicMock()
-    with patch("botocore.session.get_session") as get_session:
-        s3_client = MagicMock()
-        create_client = MagicMock(return_value=s3_client)
-        get_session.return_value = MagicMock(create_client=create_client)
-        S3Transfer(
-            region="test-region",
-            bucket_name="test-bucket",
-            notifier=notifier,
+    else:
+        # size was known and it was small enough so default of
+        # True won't be used in None case
+        s3_client.put_object.assert_called_once_with(
+            Bucket="test-bucket",
+            Body=b"test-data",
+            Key="test-prefix/test_key2",
+            Metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"},
         )
-        mock_operation.assert_called_once_with(StorageOperation.head_request)  # pylint: disable=no-member
+        notifier.object_created.assert_called_once_with(
+            key="test_key2",
+            size=len(test_data),
+            metadata={"Content-Length": "9", "some-date": "2022-11-15 18:30:58.486644"},
+        )
+
+
+def test_operations_reporting(infra) -> None:
+    infra.operation.assert_called_once_with(StorageOperation.head_request)  # pylint: disable=no-member
+
+
+def test_deletion(infra: S3Infra) -> None:
+    infra.transfer.delete_keys(["2", "3"])
+    infra.s3_client.delete_objects.assert_called_once_with(
+        Bucket="test-bucket", Delete={"Objects": [{"Key": "test-prefix/2"}, {"Key": "test-prefix/3"}]}
+    )
+    infra.transfer.delete_key("1")
+    infra.s3_client.delete_object.assert_called_once_with(Bucket="test-bucket", Key="test-prefix/1")


### PR DESCRIPTION

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
Apparently the fixed code wasn't right either but the tests I ran on it outside were insufficient (they did not notice delete failures due to prefix being omitted as we don't parse the delete_keys response).

<!-- Provide the issue number below if it exists. -->

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

Now actually added unit tests for the s3 delete_key* and also added prefix parameter to s3 storage tests in general to ensure it is passed along to the API calls that we check. In the future better unit tests would be nice but at least these enforce that the prefix is not dropped (for the covered cases) in the future.