### PR TITLE
Enable stricter MyPy typing for Rohmu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__/
 .vagrant
 /venv/
 /.venv/
+/venv3.7/
 *.orig
 coverage.xml
 rohmu-rpm-src.tar

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 python_version = 3.9
 warn_redundant_casts = True
+disallow_any_generics = true
 
 
 [mypy-azure.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,7 @@
 python_version = 3.9
 warn_redundant_casts = True
 disallow_any_generics = true
+disallow_subclassing_any = true
 
 
 [mypy-azure.*]
@@ -13,8 +14,6 @@ ignore_missing_imports = True
 [mypy-dataclasses.*]
 ignore_missing_imports = True
 
-[mypy-googleapiclient.*]
-ignore_missing_imports = True
 
 [mypy-oauth2client.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,7 @@ python_version = 3.9
 warn_redundant_casts = True
 disallow_any_generics = true
 disallow_subclassing_any = true
+disallow_untyped_decorators = true
 
 
 [mypy-azure.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,6 +5,7 @@ disallow_any_generics = true
 disallow_incomplete_defs = true
 disallow_subclassing_any = true
 disallow_untyped_decorators = true
+disallow_untyped_defs = true
 
 
 [mypy-azure.*]
@@ -28,4 +29,3 @@ ignore_missing_imports = True
 
 [mypy-systemd.*]
 ignore_missing_imports = True
-

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,7 @@
 python_version = 3.9
 warn_redundant_casts = True
 disallow_any_generics = true
+disallow_incomplete_defs = true
 disallow_subclassing_any = true
 disallow_untyped_decorators = true
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -18,3 +18,5 @@ types-botocore
 types-httplib2
 types-mock
 types-requests
+# Extra stubs
+google-api-python-client-stubs

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -10,6 +10,8 @@ pylint-quotes
 pytest
 pytest-cov
 pytest-mock
+pytest-timeout
+pytest-asyncio
 # Same version from pghoard
 isort==5.10.1
 types-python-dateutil

--- a/rohmu.spec
+++ b/rohmu.spec
@@ -10,7 +10,7 @@ Requires:       python3-azure-core
 Requires:       python3-azure-storage-blob
 Requires:       python3-boto3
 Requires:       python3-botocore
-Requires:       python3-cryptography >= 0.8
+Requires:       python3-cryptography >= 1.6
 Requires:       python3-dateutil
 Requires:       python3-pydantic
 Requires:       python3-requests

--- a/rohmu/__init__.py
+++ b/rohmu/__init__.py
@@ -8,8 +8,8 @@ See LICENSE for details
 from .common.models import StorageModel
 from .errors import InvalidConfigurationError
 from .notifier.interface import Notifier
-from .object_storage.base import BaseTransfer
-from typing import Any, Dict, Mapping, Type
+from .object_storage.base import BaseTransfer, StorageModelT
+from typing import Any, cast, Dict, Mapping, Type, TypeVar
 
 IO_BLOCK_SIZE = 2**20  # 1 MiB
 STORAGE_TYPE = "storage_type"
@@ -17,37 +17,37 @@ NOTIFIER_TYPE = "notifier_type"
 Config = Mapping[str, Any]
 
 
-def get_class_for_transfer(obj_store: Config) -> Type[BaseTransfer]:
+def get_class_for_transfer(obj_store: Config) -> Type[BaseTransfer[StorageModel]]:
     storage_type = obj_store[STORAGE_TYPE]
     if storage_type == "azure":
         from .object_storage.azure import AzureTransfer
 
-        return AzureTransfer
+        return cast(Type[BaseTransfer[StorageModel]], AzureTransfer)
     elif storage_type == "google":
         from .object_storage.google import GoogleTransfer
 
-        return GoogleTransfer
+        return cast(Type[BaseTransfer[StorageModel]], GoogleTransfer)
     elif storage_type == "sftp":
         from .object_storage.sftp import SFTPTransfer
 
-        return SFTPTransfer
+        return cast(Type[BaseTransfer[StorageModel]], SFTPTransfer)
     elif storage_type == "local":
         from .object_storage.local import LocalTransfer
 
-        return LocalTransfer
+        return cast(Type[BaseTransfer[StorageModel]], LocalTransfer)
     elif storage_type == "s3":
         from .object_storage.s3 import S3Transfer
 
-        return S3Transfer
+        return cast(Type[BaseTransfer[StorageModel]], S3Transfer)
     elif storage_type == "swift":
         from .object_storage.swift import SwiftTransfer
 
-        return SwiftTransfer
+        return cast(Type[BaseTransfer[StorageModel]], SwiftTransfer)
 
     raise InvalidConfigurationError("unsupported storage type {0!r}".format(storage_type))
 
 
-def get_class_for_notifier(notifier_config: dict) -> Type[Notifier]:
+def get_class_for_notifier(notifier_config: dict[str, Any]) -> Type[Notifier]:
     notifier_type = notifier_config[NOTIFIER_TYPE]
     if notifier_type == "http":
         from .notifier.http import BackgroundHTTPNotifier
@@ -56,14 +56,14 @@ def get_class_for_notifier(notifier_config: dict) -> Type[Notifier]:
     raise InvalidConfigurationError("unsupported storage type {0!r}".format(notifier_type))
 
 
-def get_notifier(notifier_config: dict) -> Notifier:
+def get_notifier(notifier_config: dict[str, Any]) -> Notifier:
     notificer_class = get_class_for_notifier(notifier_config)
     notifier_config = notifier_config.copy()
     notifier_config.pop(NOTIFIER_TYPE)
     return notificer_class(**notifier_config)
 
 
-def get_transfer_model(storage_config: Config) -> Type[StorageModel]:
+def get_transfer_model(storage_config: Config) -> StorageModel:
     storage_class = get_class_for_transfer(storage_config)
     storage_config = dict(storage_config)
     storage_config.pop(STORAGE_TYPE)
@@ -76,7 +76,7 @@ def get_transfer_model(storage_config: Config) -> Type[StorageModel]:
     return model
 
 
-def get_transfer(storage_config: Config) -> BaseTransfer:
+def get_transfer(storage_config: Config) -> BaseTransfer[StorageModel]:
     storage_class = get_class_for_transfer(storage_config)
     model = get_transfer_model(storage_config)
     return storage_class.from_model(model)

--- a/rohmu/__init__.py
+++ b/rohmu/__init__.py
@@ -8,13 +8,13 @@ See LICENSE for details
 from .common.models import StorageModel
 from .errors import InvalidConfigurationError
 from .notifier.interface import Notifier
-from .object_storage.base import BaseTransfer, StorageModelT
-from typing import Any, cast, Dict, Mapping, Type, TypeVar
+from .object_storage.base import BaseTransfer
+from typing import Any, cast, Dict, Type
 
 IO_BLOCK_SIZE = 2**20  # 1 MiB
 STORAGE_TYPE = "storage_type"
 NOTIFIER_TYPE = "notifier_type"
-Config = Mapping[str, Any]
+Config = Dict[str, Any]
 
 
 def get_class_for_transfer(obj_store: Config) -> Type[BaseTransfer[StorageModel]]:
@@ -47,7 +47,7 @@ def get_class_for_transfer(obj_store: Config) -> Type[BaseTransfer[StorageModel]
     raise InvalidConfigurationError("unsupported storage type {0!r}".format(storage_type))
 
 
-def get_class_for_notifier(notifier_config: dict[str, Any]) -> Type[Notifier]:
+def get_class_for_notifier(notifier_config: Config) -> Type[Notifier]:
     notifier_type = notifier_config[NOTIFIER_TYPE]
     if notifier_type == "http":
         from .notifier.http import BackgroundHTTPNotifier
@@ -56,7 +56,7 @@ def get_class_for_notifier(notifier_config: dict[str, Any]) -> Type[Notifier]:
     raise InvalidConfigurationError("unsupported storage type {0!r}".format(notifier_type))
 
 
-def get_notifier(notifier_config: dict[str, Any]) -> Notifier:
+def get_notifier(notifier_config: Config) -> Notifier:
     notificer_class = get_class_for_notifier(notifier_config)
     notifier_config = notifier_config.copy()
     notifier_config.pop(NOTIFIER_TYPE)

--- a/rohmu/atomic_opener.py
+++ b/rohmu/atomic_opener.py
@@ -1,34 +1,18 @@
 from contextlib import contextmanager
 from pathlib import Path
-from typing import BinaryIO, Callable, cast, ContextManager, Generator, Optional, overload, TextIO, TYPE_CHECKING, Union
+from typing import BinaryIO, Callable, cast, ContextManager, Generator, Optional, overload, TextIO, Union
+from typing_extensions import TypeAlias
 
-# workaround < Python3.8 missing Literal.
-# if we just use the try/except block, mypy will complain
-# about the fact that Write* variables are being redefined.
-# so we need to pour in an additional branch.
-if TYPE_CHECKING:
+try:
     from typing import Literal
-
-    Write = Literal["w"]
-    WriteBinary = Literal["wb"]
-    WriteTest = Literal["somethingrandomw"]
-else:
-    try:
-        from typing import Literal
-
-        Write = Literal["w"]
-        WriteBinary = Literal["wb"]
-        WriteTest = Literal["somethingrandomw"]
-    except ImportError:
-        from typing import Any
-
-        Write = Any
-        WriteBinary = Any
-        WriteTest = Any
-
+except ImportError:
+    from typing_extensions import Literal  # type: ignore [assignment]
 
 import errno
 import os
+
+Write: TypeAlias = Literal["w"]
+WriteBinary: TypeAlias = Literal["wb"]
 
 
 def _fd_close_quietly(fd: int) -> None:
@@ -61,19 +45,6 @@ def atomic_opener(
     _after_link_hook: Callable[[], None] = lambda: None,
 ) -> ContextManager[TextIO]:
     ...
-
-
-if TYPE_CHECKING:
-    # necessary for testing or tests will fail type checking
-    @overload
-    def atomic_opener(
-        final_path: Path,
-        mode: WriteTest,
-        encoding: Optional[str] = None,
-        _fd_spy: Callable[[int], None] = lambda unused: None,
-        _after_link_hook: Callable[[], None] = lambda: None,
-    ) -> ContextManager[TextIO]:
-        ...
 
 
 def atomic_opener(

--- a/rohmu/common/models.py
+++ b/rohmu/common/models.py
@@ -54,9 +54,7 @@ class RohmuModel(pydantic.BaseModel):
         validate_all = True
 
         # Validate also assignments
-        # validate_assignment = True
-        # TBD: Figure out why this doesn't work in some unit tests;
-        # possibly the tests themselves are broken
+        validate_assignment = True
 
 
 class ProxyInfo(RohmuModel):

--- a/rohmu/common/models.py
+++ b/rohmu/common/models.py
@@ -28,7 +28,7 @@ class StorageOperation(str, enum.Enum):
     multipart_aborted = "multipart_aborted"
     multipart_complete = "multipart_complete"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.value)
 
 

--- a/rohmu/common/statsd.py
+++ b/rohmu/common/statsd.py
@@ -14,9 +14,12 @@ This is combination of:
 - pydantic configuration + explicit typing
 
 """
+
+from __future__ import annotations
+
 from contextlib import asynccontextmanager, contextmanager
 from enum import Enum
-from typing import Any, AsyncIterator, Dict, Iterator, Optional, Union
+from typing import AsyncIterator, Dict, Iterator, Optional, Union
 
 import pydantic
 import socket
@@ -91,7 +94,7 @@ class StatsClient:
         self._send(metric, b"ms", value, tags)
 
     def unexpected_exception(self, ex: BaseException, where: str, *, tags: Optional[Tags] = None) -> None:
-        all_tags: dict[str, Any] = {
+        all_tags: Tags = {
             "exception": ex.__class__.__name__,
             "where": where,
         }

--- a/rohmu/common/statsd.py
+++ b/rohmu/common/statsd.py
@@ -27,7 +27,7 @@ class MessageFormat(str, Enum):
     datadog = "datadog"
     telegraf = "telegraf"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.value)
 
 

--- a/rohmu/dates.py
+++ b/rohmu/dates.py
@@ -9,7 +9,7 @@ import dateutil.parser
 import dateutil.tz
 
 
-def parse_timestamp(ts, *, with_tz=True, assume_local=False):
+def parse_timestamp(ts: str, *, with_tz: bool = True, assume_local: bool = False) -> datetime.datetime:
     """Parse a given timestamp and return a datetime object with or without tzinfo.
 
     If `with_tz` is False and we can't parse a timezone from the timestamp the datetime object is returned
@@ -24,7 +24,7 @@ def parse_timestamp(ts, *, with_tz=True, assume_local=False):
 
     # pylint thinks dateutil.parser.parse always returns a tuple even though we didn't request it.
     # So this check is pointless but convinces pylint that we really have a datetime object now.
-    dt = parse_result[0] if isinstance(parse_result, tuple) else parse_result  # pylint: disable=unsubscriptable-object
+    dt = parse_result[0] if isinstance(parse_result, tuple) else parse_result  # type: ignore [index] # pylint: disable=unsubscriptable-object
 
     if with_tz is False:
         if not dt.tzinfo:
@@ -40,5 +40,5 @@ def parse_timestamp(ts, *, with_tz=True, assume_local=False):
     return dt.replace(tzinfo=tz)
 
 
-def now():
+def now() -> datetime.datetime:
     return datetime.datetime.now(datetime.timezone.utc)

--- a/rohmu/dates.py
+++ b/rohmu/dates.py
@@ -20,11 +20,7 @@ def parse_timestamp(ts: str, *, with_tz: bool = True, assume_local: bool = False
     When `with_tz` is True and there's a timezone in the timestamp we return it as-is.  If `with_tz` is True
     but we can't parse a timezone we add either local or UTC timezone to the datetime based on `assume_local`.
     """
-    parse_result = dateutil.parser.parse(ts)
-
-    # pylint thinks dateutil.parser.parse always returns a tuple even though we didn't request it.
-    # So this check is pointless but convinces pylint that we really have a datetime object now.
-    dt = parse_result[0] if isinstance(parse_result, tuple) else parse_result  # type: ignore [index] # pylint: disable=unsubscriptable-object
+    dt = dateutil.parser.parse(ts)
 
     if with_tz is False:
         if not dt.tzinfo:

--- a/rohmu/delta/common.py
+++ b/rohmu/delta/common.py
@@ -5,7 +5,7 @@ from multiprocessing.dummy import Pool
 from pathlib import Path
 from pydantic import BaseModel, Field
 from rohmu.dates import now
-from typing import List, Optional
+from typing import Any, Callable, Iterable, List, Optional
 
 import functools
 import hashlib
@@ -284,7 +284,9 @@ class Progress(DeltaModel):
         return p
 
 
-def parallel_map_to(*, fun, iterable, result_callback, n=None) -> bool:
+def parallel_map_to(
+    *, fun: Callable[[Any], Any], iterable: Iterable[Any], result_callback: Callable[..., bool], n: Optional[int] = None
+) -> bool:
     iterable_as_list = list(iterable)
     with Pool(n) as p:
         for map_in, map_out in zip(iterable_as_list, p.imap(fun, iterable_as_list)):

--- a/rohmu/delta/common.py
+++ b/rohmu/delta/common.py
@@ -1,4 +1,7 @@
 # Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import datetime
 from multiprocessing.dummy import Pool

--- a/rohmu/delta/common.py
+++ b/rohmu/delta/common.py
@@ -100,7 +100,7 @@ class SizeLimitedFile:
         self._file_size = file_size
         self.tell = self._f.tell
 
-    def __enter__(self) -> "SizeLimitedFile":
+    def __enter__(self) -> SizeLimitedFile:
         return self
 
     def __exit__(self, t: Optional[Type[BaseException]], v: Optional[BaseException], tb: Optional[TracebackType]) -> None:
@@ -156,14 +156,14 @@ class SnapshotFile(DeltaModel):
     should_be_bundled: bool = False
     missing_ok: bool = True
 
-    def __lt__(self, o: "SnapshotFile") -> bool:
+    def __lt__(self, o: SnapshotFile) -> bool:
         # In our use case, paths uniquely identify files we care about
         return self.relative_path < o.relative_path
 
     def __hash__(self) -> int:
         return hash(self.relative_path)
 
-    def equals_excluding_mtime(self, o: "SnapshotFile") -> bool:
+    def equals_excluding_mtime(self, o: SnapshotFile) -> bool:
         return self.copy(update={"mtime_ns": 0}) == o.copy(update={"mtime_ns": 0})
 
     def open_for_reading(self, root_path: Path) -> SizeLimitedFile:
@@ -279,7 +279,7 @@ class Progress(DeltaModel):
         return self.final and not self.finished_successfully
 
     @classmethod
-    def merge(cls, progresses: Sequence["Progress"]) -> "Progress":
+    def merge(cls, progresses: Sequence[Progress]) -> Progress:
         p = cls()
         for progress in progresses:
             p.handled += progress.handled

--- a/rohmu/delta/snapshot.py
+++ b/rohmu/delta/snapshot.py
@@ -1,4 +1,7 @@
 # Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+
+from __future__ import annotations
+
 from pathlib import Path
 from rohmu.delta.common import (
     BackupPath,

--- a/rohmu/delta/snapshot.py
+++ b/rohmu/delta/snapshot.py
@@ -45,13 +45,13 @@ class Snapshotter:
     def __init__(
         self,
         *,
-        src,
-        dst,
-        globs,
+        src: Union[str, os.PathLike[str]],
+        dst: Union[str, os.PathLike[str]],
+        globs: list[str],
         src_iterate_func: Optional[Callable[[], Iterable[Union[BackupPath, str, Path]]]] = None,
         parallel: int = 1,
         min_delta_file_size: int = 0,
-    ):
+    ) -> None:
         assert globs
         self.src = Path(src)
         self.dst = Path(dst)
@@ -275,7 +275,7 @@ class Snapshotter:
 
         progress.add_total(len(snapshotfiles))
 
-        def _cb(snapshotfile: SnapshotFile):
+        def _cb(snapshotfile: SnapshotFile) -> SnapshotFile:
             # src may or may not be present; dst is present as it is in snapshot
             with snapshotfile.open_for_reading(self.dst) as f:
                 if snapshotfile.file_size <= EMBEDDED_FILE_SIZE:

--- a/rohmu/delta/snapshot.py
+++ b/rohmu/delta/snapshot.py
@@ -290,7 +290,7 @@ class Snapshotter:
                     snapshotfile.hexdigest = hash_hexdigest_readable(f)
             return snapshotfile
 
-        def _result_cb(*, map_in: Any, map_out: "SnapshotFile") -> bool:
+        def _result_cb(*, map_in: Any, map_out: SnapshotFile) -> bool:
             self._add_snapshotfile(map_out)
             assert progress is not None
             progress.add_success()

--- a/rohmu/delta/snapshot.py
+++ b/rohmu/delta/snapshot.py
@@ -11,7 +11,7 @@ from rohmu.delta.common import (
     SnapshotHash,
     SnapshotState,
 )
-from typing import Callable, Dict, Generator, Iterable, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 import base64
 import logging
@@ -286,8 +286,9 @@ class Snapshotter:
                     snapshotfile.hexdigest = hash_hexdigest_readable(f)
             return snapshotfile
 
-        def _result_cb(*, map_in, map_out):
+        def _result_cb(*, map_in: Any, map_out: "SnapshotFile") -> bool:
             self._add_snapshotfile(map_out)
+            assert progress is not None
             progress.add_success()
             return True
 

--- a/rohmu/delta/snapshot.py
+++ b/rohmu/delta/snapshot.py
@@ -11,6 +11,7 @@ from rohmu.delta.common import (
     SnapshotHash,
     SnapshotState,
 )
+from rohmu.typing import StrOrPathLike
 from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 import base64
@@ -45,8 +46,8 @@ class Snapshotter:
     def __init__(
         self,
         *,
-        src: Union[str, os.PathLike[str]],
-        dst: Union[str, os.PathLike[str]],
+        src: StrOrPathLike,
+        dst: StrOrPathLike,
         globs: list[str],
         src_iterate_func: Optional[Callable[[], Iterable[Union[BackupPath, str, Path]]]] = None,
         parallel: int = 1,

--- a/rohmu/delta/snapshot.py
+++ b/rohmu/delta/snapshot.py
@@ -15,7 +15,7 @@ from rohmu.delta.common import (
     SnapshotState,
 )
 from rohmu.typing import StrOrPathLike
-from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Callable, Generator, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 import base64
 import logging
@@ -61,8 +61,8 @@ class Snapshotter:
         self.dst = Path(dst)
         self.globs = globs
         self.src_iterate_func = src_iterate_func
-        self.relative_path_to_snapshotfile: Dict[Path, SnapshotFile] = {}
-        self.hexdigest_to_snapshotfiles: Dict[str, List[SnapshotFile]] = {}
+        self.relative_path_to_snapshotfile: dict[Path, SnapshotFile] = {}
+        self.hexdigest_to_snapshotfiles: dict[str, List[SnapshotFile]] = {}
         self.parallel = parallel
         self.lock = threading.Lock()
         self.empty_dirs: List[Path] = []

--- a/rohmu/encryptor.py
+++ b/rohmu/encryptor.py
@@ -1,9 +1,11 @@
+# type: ignore
 """
 rohmu - content encryption
 
 Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
+
 
 from . import IO_BLOCK_SIZE
 from .filewrap import FileWrap, Sink, Stream

--- a/rohmu/encryptor.py
+++ b/rohmu/encryptor.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, CipherContext, modes
 from cryptography.hazmat.primitives.hashes import SHA1, SHA256
 from cryptography.hazmat.primitives.hmac import HMAC
-from typing import cast, Optional, Union
+from typing import Optional, Union
 
 import io
 import logging
@@ -34,9 +34,9 @@ class Encryptor:
     def __init__(self, rsa_public_key_pem: Union[str, bytes]):
         if not isinstance(rsa_public_key_pem, bytes):
             rsa_public_key_pem = rsa_public_key_pem.encode("ascii")
-        self.rsa_public_key = cast(
-            RSAPublicKey, serialization.load_pem_public_key(rsa_public_key_pem, backend=default_backend())
-        )
+        public_key = serialization.load_pem_public_key(rsa_public_key_pem, backend=default_backend())
+        assert isinstance(public_key, RSAPublicKey)
+        self.rsa_public_key = public_key
         self._cipher: Optional[CipherContext] = None
         self._authenticator: Optional[HMAC] = None
 

--- a/rohmu/encryptor.py
+++ b/rohmu/encryptor.py
@@ -17,16 +17,10 @@ from cryptography.hazmat.primitives.hashes import SHA1, SHA256
 from cryptography.hazmat.primitives.hmac import HMAC
 from typing import cast, Optional, Union
 
-import cryptography
-import cryptography.hazmat.backends.openssl.backend
 import io
 import logging
 import os
 import struct
-
-if cryptography.__version__ < "1.6":
-    # workaround for deadlock https://github.com/pyca/cryptography/issues/2911
-    cryptography.hazmat.backends.openssl.backend.activate_builtin_random()
 
 FILEMAGIC = b"pghoa1"
 AES_BLOCK_SIZE = 16

--- a/rohmu/errors.py
+++ b/rohmu/errors.py
@@ -32,3 +32,7 @@ class MissingLibraryError(Exception):
 
 class MaybeRecoverableError(Error):
     """An error that may be recoverable"""
+
+
+class UninitializedError(Error):
+    """Error trying to access an uninitialized resource."""

--- a/rohmu/inotify.py
+++ b/rohmu/inotify.py
@@ -49,6 +49,17 @@ IN_NONBLOCK = 0x00004000
 
 
 def parse_inotify_buffer(event_buffer: bytes) -> Iterator[tuple[int, int, int, bytes]]:
+    """Yield parsed inotify events from a raw bytes sequence.
+
+    The `event_buffer` must be a byte sequence consisting of 0 or more sequences of the kind:
+
+        +------------------+------+--------+-------------+------+
+        | Watch descriptor | Mask | Cookie | Name length | Name |
+        +------------------+------+--------+-------------+------+
+
+    This function yields successive tuples (Watch descriptor, Mask, Cookie, Name) parsed from the provided bytes.
+
+    """
     i = 0
     while i + s_size <= len(event_buffer):
         wd, mask, cookie, length = struct.unpack_from("iIII", event_buffer, i)

--- a/rohmu/inotify.py
+++ b/rohmu/inotify.py
@@ -6,7 +6,10 @@ See LICENSE for details
 """
 from contextlib import suppress
 from ctypes import c_char_p, c_int, c_uint32
+from queue import Queue
+from rohmu.typing import AnyPath
 from threading import Thread
+from typing import Iterable, Iterator, Optional
 
 import ctypes
 import logging
@@ -42,7 +45,7 @@ event_types = {
 IN_NONBLOCK = 0x00004000
 
 
-def parse_inotify_buffer(event_buffer):
+def parse_inotify_buffer(event_buffer: bytes) -> Iterator[tuple[int, int, int, bytes]]:
     i = 0
     while i + s_size <= len(event_buffer):
         wd, mask, cookie, length = struct.unpack_from("iIII", event_buffer, i)
@@ -52,20 +55,20 @@ def parse_inotify_buffer(event_buffer):
 
 
 class InotifyWatcher(Thread):
-    def __init__(self, compression_queue):
+    def __init__(self, compression_queue: Queue[dict[str, str]]) -> None:
         super().__init__()
         # use the newer form for future-proofness
         self.log = logging.getLogger("PGHoardInotify")
         self.libc = ctypes.CDLL("libc.so.6", use_errno=True)
         self.fd = self.libc.inotify_init()
-        self.watch_to_path = {}
-        self.cookies = {}
+        self.watch_to_path: dict[int, str] = {}
+        self.cookies: dict[int, str] = {}
         self.running = True
         self.compression_queue = compression_queue
         self.timeout = 1.0
         self.log.debug("InotifyWatcher initialized")
 
-    def add_watch(self, path, events=None):
+    def add_watch(self, path: str, events: Optional[Iterable[str]] = None) -> None:
         mask = 0
         events = events or event_types.keys()
         for key in events:
@@ -77,7 +80,7 @@ class InotifyWatcher(Thread):
         self.watch_to_path[watch] = path
         self.log.debug("Added watch for path: %r", path)
 
-    def read_events(self):
+    def read_events(self) -> None:
         event_buffer = None
         while self.running:
             with suppress(InterruptedError):
@@ -93,7 +96,7 @@ class InotifyWatcher(Thread):
                 continue
             self.create_event(wd, mask, cookie, name)
 
-    def log_event(self, ev_type, full_path):
+    def log_event(self, ev_type: str, full_path: AnyPath) -> None:
         if self.log.getEffectiveLevel() > logging.DEBUG:
             return
 
@@ -104,7 +107,7 @@ class InotifyWatcher(Thread):
 
         self.log.debug("event: %s %s, %r", full_path, ev_type, st)
 
-    def create_event(self, wd, mask, cookie, name):
+    def create_event(self, wd: int, mask: int, cookie: int, name: bytes) -> None:
         if mask & event_types["IN_IGNORED"]:
             # explicit removal of watch or dir, ignore
             return
@@ -148,7 +151,7 @@ class InotifyWatcher(Thread):
             else:
                 self.compression_queue.put({"type": "CREATE", "full_path": full_path, "watched_path": watched_path})
 
-    def run(self):
+    def run(self) -> None:
         self.log.debug("Starting InotifyWatcher")
         while self.running:
             self.read_events()

--- a/rohmu/inotify.py
+++ b/rohmu/inotify.py
@@ -4,6 +4,9 @@ rohmu - inotify wrapper
 Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
+
+from __future__ import annotations
+
 from contextlib import suppress
 from ctypes import c_char_p, c_int, c_uint32
 from queue import Queue

--- a/rohmu/notifier/http.py
+++ b/rohmu/notifier/http.py
@@ -85,7 +85,7 @@ def background_http_request(
 
 
 def initialize_background_thread(
-    queue: Queue,
+    queue: "Queue[HTTPNotifyJob]",
     stop_event: threading.Event,
     stop_event_check_timeout: float = _CHECK_STOP_EVENT_TIMEOUT,
     session: Optional[requests.Session] = None,
@@ -130,7 +130,7 @@ class BackgroundHTTPNotifier(Notifier):
         self._stop_event.set()
         self._thread.join(_THREAD_JOIN_TIMEOUT)
 
-    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict]) -> None:
+    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict[str, str]]) -> None:
         self._queue.put(
             HTTPNotifyJob(
                 self._url,

--- a/rohmu/notifier/http.py
+++ b/rohmu/notifier/http.py
@@ -1,4 +1,6 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from __future__ import annotations
+
 from .interface import Notifier
 from dataclasses import dataclass
 from datetime import datetime, timezone

--- a/rohmu/notifier/http.py
+++ b/rohmu/notifier/http.py
@@ -54,7 +54,7 @@ class HTTPNotifyJob:
 
 def background_http_request(
     session: requests.Session,
-    queue: "Queue[HTTPNotifyJob]",
+    queue: Queue[HTTPNotifyJob],
     stop_event: threading.Event,
     stop_event_check_timeout: float,
 ) -> None:
@@ -87,7 +87,7 @@ def background_http_request(
 
 
 def initialize_background_thread(
-    queue: "Queue[HTTPNotifyJob]",
+    queue: Queue[HTTPNotifyJob],
     stop_event: threading.Event,
     stop_event_check_timeout: float = _CHECK_STOP_EVENT_TIMEOUT,
     session: Optional[requests.Session] = None,
@@ -114,7 +114,7 @@ class BackgroundHTTPNotifier(Notifier):
         session: Optional[requests.Session] = None,
     ) -> None:
         self._url = url
-        self._queue: "Queue[HTTPNotifyJob]" = Queue()
+        self._queue: Queue[HTTPNotifyJob] = Queue()
         self._stop_event = threading.Event()
         self._thread = initialize_background_thread(
             self._queue,

--- a/rohmu/notifier/interface.py
+++ b/rohmu/notifier/interface.py
@@ -1,13 +1,13 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Optional
 
 
 class Notifier(ABC):
     """This interface allows external code to be notified about object changes."""
 
     @abstractmethod
-    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict]) -> None:
+    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict[str, str]]) -> None:
         """Called when an object is created."""
 
     @abstractmethod
@@ -28,7 +28,7 @@ class Notifier(ABC):
         called instead.
         """
 
-    def object_copied(self, key: str, size: Optional[int], metadata: Optional[dict]) -> None:
+    def object_copied(self, key: str, size: Optional[int], metadata: Optional[dict[str, str]]) -> None:
         """Called when an object is copied."""
         self.object_created(key=key, size=size, metadata=metadata)
 

--- a/rohmu/notifier/interface.py
+++ b/rohmu/notifier/interface.py
@@ -1,6 +1,6 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Optional
 
 
 class Notifier(ABC):

--- a/rohmu/notifier/interface.py
+++ b/rohmu/notifier/interface.py
@@ -1,4 +1,6 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Optional
 

--- a/rohmu/notifier/logger.py
+++ b/rohmu/notifier/logger.py
@@ -8,7 +8,7 @@ class LoggerNotifier(Notifier):
     def __init__(self, log: Logger) -> None:
         self._log = log
 
-    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict]) -> None:
+    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict[str, str]]) -> None:
         self._log.info("Object created key %r size %r", key, size)
 
     def object_deleted(self, key: str) -> None:

--- a/rohmu/notifier/logger.py
+++ b/rohmu/notifier/logger.py
@@ -1,4 +1,7 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+
+from __future__ import annotations
+
 from .interface import Notifier
 from logging import Logger
 from typing import Optional

--- a/rohmu/notifier/null.py
+++ b/rohmu/notifier/null.py
@@ -1,4 +1,7 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+
+from __future__ import annotations
+
 from .interface import Notifier
 from typing import Optional
 

--- a/rohmu/notifier/null.py
+++ b/rohmu/notifier/null.py
@@ -9,7 +9,7 @@ class NullNotifier(Notifier):
     Used by default if configuration is missing to avoid None checks
     """
 
-    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict]) -> None:
+    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict[str, str]]) -> None:
         pass
 
     def object_deleted(self, key: str) -> None:

--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -174,9 +174,11 @@ class AzureTransfer(BaseTransfer[Config]):
             # look up the matching result
             item_name: str
             if item.type == KEY_TYPE_OBJECT:
-                item_name = cast(Dict[str, str], item.value)["name"]
+                assert isinstance(item.value, dict)
+                item_name = item.value["name"]
             else:
-                item_name = cast(str, item.value)
+                assert isinstance(item.value, str)
+                item_name = item.value
             if item_name.rstrip("/").rsplit("/", 1)[-1] == expected_name:
                 break
         else:

--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -17,7 +17,7 @@ from .base import IncrementalProgressCallbackType, ProgressProportionCallbackTyp
 # pylint: disable=import-error, no-name-in-module
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.storage.blob import BlobServiceClient, ContentSettings
-from typing import Any, BinaryIO, cast, Dict, Iterator, Optional, Union
+from typing import Any, BinaryIO, Iterator, Optional, Union
 
 import azure.common
 import logging
@@ -185,10 +185,13 @@ class AzureTransfer(BaseTransfer[Config]):
             raise FileNotFoundFromStorageError(path)
         if item.type != KEY_TYPE_OBJECT:
             raise FileNotFoundFromStorageError(path)  # not found or prefix
-        return cast(Dict[str, Any], item.value)["metadata"]
+        assert isinstance(item.value, dict)
+        return item.value["metadata"]
 
     def _metadata_for_key(self, path: str) -> Metadata:
-        return cast(Dict[str, Any], list(self._iter_key(path=path, with_metadata=True, deep=False))[0].value)["metadata"]
+        result = list(self._iter_key(path=path, with_metadata=True, deep=False))[0].value
+        assert isinstance(result, dict)
+        return result["metadata"]
 
     def iter_key(
         self, key: str, *, with_metadata: bool = True, deep: bool = False, include_key: bool = False

--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -15,21 +15,7 @@ from ..notifier.null import NullNotifier
 from ..typing import AnyPath, Metadata
 from contextlib import suppress
 from io import BytesIO
-from typing import (
-    Any,
-    BinaryIO,
-    Callable,
-    cast,
-    Collection,
-    Dict,
-    Generic,
-    Iterator,
-    NamedTuple,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, BinaryIO, Callable, Collection, Generic, Iterator, NamedTuple, Optional, Type, TypeVar, Union
 
 import logging
 import os
@@ -219,7 +205,8 @@ class BaseTransfer(Generic[StorageModelT]):
     def list_iter(self, key: str, *, with_metadata: bool = True, deep: bool = False) -> Iterator[dict[str, Any]]:
         for item in self.iter_key(key, with_metadata=with_metadata, deep=deep):
             if item.type == KEY_TYPE_OBJECT:
-                yield cast(Dict[str, Any], item.value)
+                assert isinstance(item.value, dict)
+                yield item.value
 
     def list_prefixes(self, key: str) -> list[str]:
         return list(self.iter_prefixes(key))
@@ -227,7 +214,8 @@ class BaseTransfer(Generic[StorageModelT]):
     def iter_prefixes(self, key: str) -> Iterator[str]:
         for item in self.iter_key(key, with_metadata=False):
             if item.type == KEY_TYPE_PREFIX:
-                yield cast(str, item.value)
+                assert isinstance(item.value, str)
+                yield item.value
 
     def iter_key(
         self, key: str, *, with_metadata: bool = True, deep: bool = False, include_key: bool = False

--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -125,7 +125,7 @@ class BaseTransfer(Generic[StorageModelT]):
         return size > chunk_size
 
     @classmethod
-    def from_model(cls, model: StorageModelT) -> "BaseTransfer[StorageModelT]":
+    def from_model(cls, model: StorageModelT) -> BaseTransfer[StorageModelT]:
         return cls(**model.dict(by_alias=True))
 
     def copy_file(

--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -5,6 +5,8 @@ Copyright (c) 2016 Ohmu Ltd
 Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/
 See LICENSE for details
 """
+from __future__ import annotations
+
 from ..common.models import StorageModel
 from ..common.statsd import StatsClient, StatsdConfig
 from ..errors import FileNotFoundFromStorageError, StorageError
@@ -302,7 +304,7 @@ class BaseTransfer(Generic[StorageModelT]):
         mimetype: Optional[str] = None,
         multipart: Optional[bool] = None,
         upload_progress_fn: IncrementalProgressCallbackType = None,
-    ) -> Any:
+    ) -> None:
         raise NotImplementedError
 
 

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -28,7 +28,7 @@ from googleapiclient.http import build_http, MediaDownloadProgress, MediaIoBaseD
 from http.client import IncompleteRead
 from oauth2client import GOOGLE_TOKEN_URI
 from oauth2client.client import GoogleCredentials
-from typing import Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 
 import codecs
 import dataclasses
@@ -157,7 +157,7 @@ class Config(StorageModel):
     project_id: str
     bucket_name: str
     credential_file: Optional[str] = None
-    credentials: Optional[dict] = None
+    credentials: Optional[dict[str, Any]] = None
     proxy_info: Optional[ProxyInfo] = None
     prefix: Optional[str] = None
 
@@ -306,7 +306,7 @@ class GoogleTransfer(BaseTransfer[Config]):
         with self._object_client(not_found=path) as clob:
             return self._metadata_for_key(clob, path)[0]
 
-    def _metadata_for_key(self, clob, key) -> Tuple[dict, int]:
+    def _metadata_for_key(self, clob, key) -> Tuple[dict[str, Any], int]:
         # https://googleapis.github.io/google-api-python-client/docs/dyn/storage_v1.objects.html#get
         req = clob.get(bucket=self.bucket_name, object=key)
 

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -37,7 +37,7 @@ from googleapiclient.http import (
 from http.client import IncompleteRead
 from oauth2client import GOOGLE_TOKEN_URI
 from oauth2client.client import GoogleCredentials
-from typing import Any, BinaryIO, Callable, cast, Dict, Iterable, Iterator, Optional, TextIO, Tuple, TypeVar, Union
+from typing import Any, BinaryIO, Callable, cast, Dict, Iterable, Iterator, Optional, TextIO, TypeVar, Union
 
 import codecs
 import dataclasses
@@ -186,9 +186,9 @@ class GoogleTransfer(BaseTransfer[Config]):
         project_id: str,
         bucket_name: str,
         credential_file: Optional[TextIO] = None,
-        credentials: Optional[Dict[str, Any]] = None,
+        credentials: Optional[dict[str, Any]] = None,
         prefix: Optional[str] = None,
-        proxy_info: Optional[Dict[str, Union[str, int]]] = None,
+        proxy_info: Optional[dict[str, Union[str, int]]] = None,
         notifier: Optional[Notifier] = None,
         statsd_info: Optional[StatsdConfig] = None,
     ) -> None:
@@ -323,7 +323,7 @@ class GoogleTransfer(BaseTransfer[Config]):
         with self._object_client(not_found=path) as clob:
             return self._metadata_for_key(clob, path)[0]
 
-    def _metadata_for_key(self, clob: Any, key: str) -> Tuple[Dict[str, Any], int]:
+    def _metadata_for_key(self, clob: Any, key: str) -> tuple[dict[str, Any], int]:
         # https://googleapis.github.io/google-api-python-client/docs/dyn/storage_v1.objects.html#get
         req = clob.get(bucket=self.bucket_name, object=key)
 
@@ -455,7 +455,7 @@ class GoogleTransfer(BaseTransfer[Config]):
         upload: MediaUpload,
         key: str,
         metadata: Metadata,
-        extra_props: Optional[Dict[str, Any]],
+        extra_props: Optional[dict[str, Any]],
         cache_control: Optional[str],
         reporter: Reporter,
         upload_progress_fn: IncrementalProgressCallbackType = None,
@@ -507,7 +507,7 @@ class GoogleTransfer(BaseTransfer[Config]):
         mimetype: Optional[str] = None,
         multipart: Optional[bool] = None,
         progress_fn: ProgressProportionCallbackType = None,
-        extra_props: Optional[Dict[str, Any]] = None,  # pylint: disable=arguments-differ
+        extra_props: Optional[dict[str, Any]] = None,  # pylint: disable=arguments-differ
     ) -> None:  # pylint: disable=unused-argument
         # TODO: extra_props seems to be used only to set cacheControl in pghoard tests.
         #
@@ -539,7 +539,7 @@ class GoogleTransfer(BaseTransfer[Config]):
         mimetype: Optional[str] = None,
         multipart: Optional[bool] = None,  # pylint: disable=unused-argument
         upload_progress_fn: IncrementalProgressCallbackType = None,
-        extra_props: Optional[Dict[str, Any]] = None,  # pylint: disable=arguments-differ
+        extra_props: Optional[dict[str, Any]] = None,  # pylint: disable=arguments-differ
     ) -> None:
         mimetype = mimetype or "application/octet-stream"
         sanitized_metadata = self.sanitize_metadata(metadata)

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -9,6 +9,7 @@ from ..common.models import StorageModel
 from ..common.statsd import StatsdConfig
 from ..errors import FileNotFoundFromStorageError
 from ..notifier.interface import Notifier
+from ..typing import Metadata
 from .base import (
     BaseTransfer,
     IncrementalProgressCallbackType,
@@ -17,7 +18,7 @@ from .base import (
     KEY_TYPE_PREFIX,
     ProgressProportionCallbackType,
 )
-from typing import Optional, Union
+from typing import BinaryIO, Optional, Union
 
 import contextlib
 import datetime
@@ -39,8 +40,8 @@ class LocalTransfer(BaseTransfer[Config]):
 
     def __init__(
         self,
-        directory,
-        prefix=None,
+        directory: str,
+        prefix: Optional[str] = None,
         notifier: Optional[Notifier] = None,
         statsd_info: Optional[StatsdConfig] = None,
     ) -> None:
@@ -155,7 +156,9 @@ class LocalTransfer(BaseTransfer[Config]):
                     with_metadata=with_metadata,
                 )
 
-    def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback: ProgressProportionCallbackType = None):
+    def get_contents_to_fileobj(
+        self, key: str, fileobj_to_store_to: BinaryIO, *, progress_callback: ProgressProportionCallbackType = None
+    ) -> Metadata:
         source_path = self.format_key_for_backend(key.strip("/"))
         if not os.path.exists(source_path):
             raise FileNotFoundFromStorageError(key)
@@ -187,15 +190,15 @@ class LocalTransfer(BaseTransfer[Config]):
 
     def store_file_object(
         self,
-        key,
-        fd,
-        metadata=None,
+        key: str,
+        fd: BinaryIO,
+        metadata: Optional[Metadata] = None,
         *,
-        cache_control=None,
-        mimetype=None,
-        multipart: Union[bool, None] = None,
+        cache_control: Optional[str] = None,
+        mimetype: Optional[str] = None,
+        multipart: Optional[bool] = None,
         upload_progress_fn: IncrementalProgressCallbackType = None,
-    ):  # pylint: disable=unused-argument
+    ) -> None:  # pylint: disable=unused-argument
         target_path = self.format_key_for_backend(key.strip("/"))
         os.makedirs(os.path.dirname(target_path), exist_ok=True)
         bytes_written = 0

--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -23,7 +23,7 @@ from .base import (
     ProgressProportionCallbackType,
 )
 from botocore.response import StreamingBody
-from typing import Any, BinaryIO, Collection, Dict, Iterator, Optional, Union
+from typing import Any, BinaryIO, Collection, Iterator, Optional, Union
 
 import boto3
 import botocore.client
@@ -139,7 +139,7 @@ class S3Transfer(BaseTransfer[Config]):
                 self.location = self.region
             else:
                 signature_version = "s3"
-            proxies: Optional[Dict[str, str]] = None
+            proxies: Optional[dict[str, str]] = None
             if proxy_info:
                 proxies = {"https": get_proxy_url(proxy_info)}
             boto_config = botocore.client.Config(

--- a/rohmu/object_storage/sftp.py
+++ b/rohmu/object_storage/sftp.py
@@ -19,7 +19,7 @@ from .base import (
     KEY_TYPE_PREFIX,
     ProgressProportionCallbackType,
 )
-from io import BytesIO, StringIO
+from io import BytesIO
 from stat import S_ISDIR
 from typing import Any, BinaryIO, cast, Iterator, Optional
 
@@ -137,7 +137,9 @@ class SFTPTransfer(BaseTransfer[Config]):
                     else:
                         metadata = None
 
-                    last_modified = datetime.datetime.fromtimestamp(attr.st_mtime, tz=datetime.timezone.utc)  # type: ignore
+                    last_modified = datetime.datetime.fromtimestamp(
+                        attr.st_mtime, tz=datetime.timezone.utc  # type: ignore [arg-type]
+                    )
                     yield IterKeyItem(
                         type=KEY_TYPE_OBJECT,
                         value={
@@ -160,7 +162,7 @@ class SFTPTransfer(BaseTransfer[Config]):
                 continue
 
             file_key = os.path.join(key.strip("/"), attr.filename)
-            if S_ISDIR(attr.st_mode):  # type: ignore
+            if S_ISDIR(attr.st_mode):  # type: ignore [arg-type]
                 if deep:
                     yield from self.iter_key(file_key, with_metadata=with_metadata, deep=True)
                 else:
@@ -174,7 +176,9 @@ class SFTPTransfer(BaseTransfer[Config]):
                     else:
                         metadata = None
 
-                    last_modified = datetime.datetime.fromtimestamp(attr.st_mtime, tz=datetime.timezone.utc)  # type: ignore
+                    last_modified = datetime.datetime.fromtimestamp(
+                        attr.st_mtime, tz=datetime.timezone.utc  # type: ignore [arg-type]
+                    )
                     yield IterKeyItem(
                         type=KEY_TYPE_OBJECT,
                         value={
@@ -252,8 +256,8 @@ class SFTPTransfer(BaseTransfer[Config]):
         self.log.debug("Save metadata: %r", metadata_path)
 
         sanitised = self.sanitize_metadata(metadata)
-        bio = StringIO(json.dumps(sanitised))  # FIXME: should this be BytesIO?
-        self.client.putfo(fl=bio, remotepath=metadata_path)  # type: ignore
+        bio = BytesIO(json.dumps(sanitised).encode())
+        self.client.putfo(fl=bio, remotepath=metadata_path)
 
     # https://stackoverflow.com/questions/14819681/upload-files-using-sftp-in-python-but-create-directories-if-path-doesnt-exist
     def _mkdir_p(self, remote: str) -> None:

--- a/rohmu/object_storage/swift.py
+++ b/rohmu/object_storage/swift.py
@@ -5,6 +5,9 @@ Copyright (c) 2016 Ohmu Ltd
 Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/
 See LICENSE for details
 """
+
+from __future__ import annotations
+
 from ..common.models import StorageModel
 from ..common.statsd import StatsdConfig
 from ..dates import parse_timestamp

--- a/rohmu/rohmufile.py
+++ b/rohmu/rohmufile.py
@@ -4,6 +4,9 @@ rohmu - rohmu data transformation interface
 Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
+
+from __future__ import annotations
+
 from . import IO_BLOCK_SIZE
 from .compressor import CompressionFile, DecompressionFile, DecompressSink
 from .encryptor import DecryptorFile, DecryptSink, EncryptorFile

--- a/rohmu/rohmufile.py
+++ b/rohmu/rohmufile.py
@@ -6,7 +6,7 @@ See LICENSE for details
 """
 from . import IO_BLOCK_SIZE
 from .compressor import CompressionFile, DecompressionFile, DecompressSink
-from .encryptor import DecryptorFile, DecryptSink, EncryptorFile
+from .encryptor import DecryptorFile, DecryptSink, EncryptorFile  # type: ignore
 from .errors import InvalidConfigurationError
 from .filewrap import ThrottleSink
 from .object_storage.base import IncrementalProgressCallbackType
@@ -14,12 +14,12 @@ from .typing import Metadata
 from contextlib import suppress
 from inspect import signature
 from io import IOBase
-from typing import BinaryIO, Callable, Optional
+from typing import BinaryIO, Callable, Optional, Union
 
 import time
 
 
-def _fileobj_name(input_obj):
+def _fileobj_name(input_obj: Union[IOBase, BinaryIO]) -> str:
     if hasattr(input_obj, "name"):
         return "open file {!r}".format(getattr(input_obj, "name"))
 
@@ -45,7 +45,7 @@ def _get_encryption_key_data(
 
 def file_reader(
     *, fileobj: IOBase, metadata: Optional[Metadata] = None, key_lookup: Optional[Callable[[str], Optional[str]]] = None
-) -> IOBase:
+) -> IOBase:  # type: ignore
     if not metadata:
         return fileobj
 
@@ -55,12 +55,12 @@ def file_reader(
 
     comp_alg = metadata.get("compression-algorithm")
     if comp_alg:
-        fileobj = DecompressionFile(fileobj, comp_alg)
+        fileobj = DecompressionFile(fileobj, comp_alg)  # type: ignore
 
     return fileobj
 
 
-def create_sink_pipeline(*, output, file_size=None, metadata=None, key_lookup=None, throttle_time=0.001):
+def create_sink_pipeline(*, output, file_size=None, metadata=None, key_lookup=None, throttle_time=0.001):  # type: ignore
     if throttle_time:
         output = ThrottleSink(output, throttle_time)
 
@@ -127,7 +127,9 @@ def read_file(
     return original_size, result_size
 
 
-def file_writer(*, fileobj, compression_algorithm=None, compression_level=0, compression_threads=0, rsa_public_key=None):
+def file_writer(  # type: ignore
+    *, fileobj, compression_algorithm=None, compression_level=0, compression_threads=0, rsa_public_key=None
+):
     if rsa_public_key:
         fileobj = EncryptorFile(fileobj, rsa_public_key)
 
@@ -137,7 +139,7 @@ def file_writer(*, fileobj, compression_algorithm=None, compression_level=0, com
     return fileobj
 
 
-def write_file(
+def write_file(  # type: ignore
     *,
     input_obj,
     output_obj,
@@ -194,7 +196,9 @@ def write_file(
     return original_size, result_size
 
 
-def log_compression_result(*, log_func, source_name, original_size, result_size, encrypted, elapsed):
+def log_compression_result(
+    *, log_func: Callable[..., None], source_name: str, original_size: int, result_size: int, encrypted: bool, elapsed: float
+) -> None:
     if original_size <= result_size:
         action = "Stored"
         ratio = ""

--- a/rohmu/snappyfile.py
+++ b/rohmu/snappyfile.py
@@ -6,8 +6,8 @@ See LICENSE for details
 """
 from . import IO_BLOCK_SIZE
 from .filewrap import FileWrap
-from .typing import BinaryData
-from typing import BinaryIO, Optional
+from .typing import BinaryData, FileLike
+from typing import Optional
 
 import io
 
@@ -18,7 +18,7 @@ except ImportError:
 
 
 class SnappyFile(FileWrap):
-    def __init__(self, next_fp: BinaryIO, mode: str) -> None:
+    def __init__(self, next_fp: FileLike, mode: str) -> None:
         if snappy is None:
             raise io.UnsupportedOperation("Snappy is not available")
 
@@ -39,7 +39,6 @@ class SnappyFile(FileWrap):
             return
         if self.encr:
             data = self.encr.flush() or b""
-            assert self.next_fp is not None
             if data:
                 self.next_fp.write(data)
             self.next_fp.flush()
@@ -51,7 +50,6 @@ class SnappyFile(FileWrap):
             raise io.UnsupportedOperation("file not open for writing")
         data_as_bytes = bytes(data)
         compressed_data = self.encr.compress(data_as_bytes)
-        assert self.next_fp is not None
         self.next_fp.write(compressed_data)
         self.offset += len(data_as_bytes)
         return len(data_as_bytes)
@@ -65,7 +63,6 @@ class SnappyFile(FileWrap):
         if self.decr is None:
             raise io.UnsupportedOperation("file not open for reading")
         while not self.decr_done:
-            assert self.next_fp is not None
             compressed = self.next_fp.read(IO_BLOCK_SIZE)
             if not compressed:
                 self.decr_done = True

--- a/rohmu/typing.py
+++ b/rohmu/typing.py
@@ -1,0 +1,6 @@
+from os import PathLike
+from typing import Any, Union
+
+Metadata = dict[str, Any]
+
+AnyPath = Union[str, bytes, PathLike[str], PathLike[bytes]]

--- a/rohmu/typing.py
+++ b/rohmu/typing.py
@@ -1,6 +1,40 @@
+from array import array
 from os import PathLike
-from typing import Any, Union
+from pickle import PickleBuffer
+from typing import Any, Protocol, Union
+
+import ctypes
+import mmap
 
 Metadata = dict[str, Any]
 
 AnyPath = Union[str, bytes, PathLike[str], PathLike[bytes]]
+
+
+class HasFileno(Protocol):
+    def fileno(self) -> int:
+        ...
+
+
+class Compressor(Protocol):
+    def compress(self, data: bytes) -> Any:
+        ...
+
+    def flush(self) -> bytes:
+        ...
+
+
+class Decompressor(Protocol):
+    def decompress(self, data: bytes) -> bytes:
+        ...
+
+
+BinaryData = Union[
+    bytes,
+    bytearray,
+    memoryview,
+    array[Any],  # pylint: disable=unsubscriptable-object
+    mmap.mmap,
+    ctypes._CData,  # pylint: disable=no-member,protected-access
+    PickleBuffer,
+]

--- a/rohmu/typing.py
+++ b/rohmu/typing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from types import TracebackType
 from typing import Any, Dict, Optional, Type, TYPE_CHECKING, Union
 
@@ -52,7 +54,7 @@ class HasWrite(Protocol):
 
 
 class FileLike(Protocol):
-    def __enter__(self) -> "FileLike":
+    def __enter__(self) -> FileLike:
         ...
 
     def __exit__(

--- a/rohmu/util.py
+++ b/rohmu/util.py
@@ -4,6 +4,9 @@ rohmu - common utility functions
 Copyright (c) 2022 Ohmu Ltd
 See LICENSE for details
 """
+from rohmu.typing import HasFileno
+from typing import Union
+
 import fcntl
 import logging
 import os
@@ -12,7 +15,7 @@ import platform
 LOG = logging.getLogger("rohmu.util")
 
 
-def increase_pipe_capacity(*pipes):
+def increase_pipe_capacity(*pipes: Union[int, HasFileno]) -> None:
     if platform.system() != "Linux":
         return
     try:
@@ -41,7 +44,7 @@ def increase_pipe_capacity(*pipes):
                 pass
 
 
-def set_stream_nonblocking(stream):
+def set_stream_nonblocking(stream: HasFileno) -> None:
     fd = stream.fileno()
     fl = fcntl.fcntl(fd, fcntl.F_GETFL)
     fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     python-snappy
     requests
     zstandard
+    typing_extensions >= 3.10, < 5
 [options.packages.find]
 where = .
 include = rohmu*

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,18 +2,18 @@ from pathlib import Path
 from rohmu.delta.common import Progress
 from rohmu.delta.snapshot import Snapshotter
 from rohmu.object_storage.local import LocalTransfer
-from typing import Dict
+from typing import Any, Callable, Dict, Union
 
 import pytest
 
 
 @pytest.fixture(name="local_transfer")
-def local_transfer(tmp_path):
+def local_transfer(tmp_path: Path) -> LocalTransfer:
     return LocalTransfer(tmp_path / "local_storage")
 
 
 class SnapshotterWithDefaults(Snapshotter):
-    def create_samples(self, samples: Dict[Path, str]) -> None:
+    def create_samples(self, samples: Dict[Union[str, Path], str]) -> None:
         for file_name, body in samples.items():
             (self.src / file_name).write_text(body)
         progress = Progress()
@@ -27,8 +27,8 @@ class SnapshotterWithDefaults(Snapshotter):
 
 
 @pytest.fixture(name="snapshotter_creator")
-def fixture_snapshotter_creator(tmp_path):
-    def create_snapshotter(**kwargs):
+def fixture_snapshotter_creator(tmp_path: Path) -> Callable[..., SnapshotterWithDefaults]:
+    def create_snapshotter(**kwargs: Any) -> SnapshotterWithDefaults:
         src = tmp_path / "src"
         src.mkdir()
         dst = tmp_path / "dst"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from pathlib import Path
 from rohmu.delta.common import Progress
 from rohmu.delta.snapshot import Snapshotter
 from rohmu.object_storage.local import LocalTransfer
-from typing import Any, Callable, Dict, Union
+from typing import Any, Callable, Union
 
 import pytest
 
@@ -13,7 +15,7 @@ def local_transfer(tmp_path: Path) -> LocalTransfer:
 
 
 class SnapshotterWithDefaults(Snapshotter):
-    def create_samples(self, samples: Dict[Union[str, Path], str]) -> None:
+    def create_samples(self, samples: dict[Union[str, Path], str]) -> None:
         for file_name, body in samples.items():
             (self.src / file_name).write_text(body)
         progress = Progress()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,7 @@ def local_transfer(tmp_path):
 
 
 class SnapshotterWithDefaults(Snapshotter):
-    def create_samples(self, samples: Dict[Path, str]):
+    def create_samples(self, samples: Dict[Path, str]) -> None:
         for file_name, body in samples.items():
             (self.src / file_name).write_text(body)
         progress = Progress()

--- a/test/delta/test_snapshot.py
+++ b/test/delta/test_snapshot.py
@@ -1,4 +1,7 @@
 # Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+
+from __future__ import annotations
+
 from pathlib import Path
 from rohmu.delta.common import BackupPath, EMBEDDED_FILE_SIZE, Progress, SizeLimitedFile, SnapshotFile, SnapshotHash
 from rohmu.typing import AnyPath

--- a/test/delta/test_snapshot.py
+++ b/test/delta/test_snapshot.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
 from pathlib import Path
-from rohmu.delta.common import BackupPath, EMBEDDED_FILE_SIZE, Progress, SnapshotFile, SnapshotHash
+from rohmu.delta.common import BackupPath, EMBEDDED_FILE_SIZE, Progress, SizeLimitedFile, SnapshotFile, SnapshotHash
 
 import mock
 import os
@@ -173,7 +173,7 @@ def test_snapshot_error_when_required_files_not_found(snapshotter_creator):
 
         orig_open_for_reading = SnapshotFile.open_for_reading
 
-        def fake_open_for_reading(self, path: Path):
+        def fake_open_for_reading(self: SnapshotFile, path: Path) -> SizeLimitedFile:
             if self.relative_path.name == "foo":
                 raise FileNotFoundError()
             return orig_open_for_reading(self, path)

--- a/test/notifier/test_http.py
+++ b/test/notifier/test_http.py
@@ -32,7 +32,7 @@ class _TestSession:
         pass
 
 
-def _join_queue_with_timeout(queue: Queue, *, timeout: float, iteration: float = 0.1) -> None:
+def _join_queue_with_timeout(queue: "Queue[HTTPNotifyJob]", *, timeout: float, iteration: float = 0.1) -> None:
     while queue.unfinished_tasks and timeout > 0.0:
         time.sleep(iteration)
         timeout -= iteration

--- a/test/notifier/test_http.py
+++ b/test/notifier/test_http.py
@@ -1,4 +1,6 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from __future__ import annotations
+
 from contextlib import closing, contextmanager
 from datetime import datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -35,7 +37,7 @@ class _TestSession:
         pass
 
 
-def _join_queue_with_timeout(queue: "Queue[HTTPNotifyJob]", *, timeout: float, iteration: float = 0.1) -> None:
+def _join_queue_with_timeout(queue: Queue[HTTPNotifyJob], *, timeout: float, iteration: float = 0.1) -> None:
     while queue.unfinished_tasks and timeout > 0.0:
         time.sleep(iteration)
         timeout -= iteration
@@ -102,7 +104,7 @@ def test_background_http_request() -> None:
     session = _TestSession()
     stop_event = threading.Event()
     stop_event_check_timeout = 0.2
-    queue: "Queue[HTTPNotifyJob]" = Queue()
+    queue: Queue[HTTPNotifyJob] = Queue()
     url = "http://test_background_http_request.com"
     data = json.dumps(["test", "background", "http", "request"])
 
@@ -134,7 +136,7 @@ def test_background_http_request() -> None:
 def test_initialize_background_thread() -> None:
     stop_event = threading.Event()
     stop_event_check_timeout = 0.2
-    queue: "Queue[HTTPNotifyJob]" = Queue()
+    queue: Queue[HTTPNotifyJob] = Queue()
     thread = initialize_background_thread(
         queue,
         stop_event,

--- a/test/notifier/test_http.py
+++ b/test/notifier/test_http.py
@@ -10,7 +10,8 @@ from rohmu.notifier.http import (
     initialize_background_thread,
     Operation,
 )
-from typing import Any, Iterator, List, Tuple
+from types import TracebackType
+from typing import Any, Iterator, List, Tuple, Type
 
 import json
 import requests
@@ -19,16 +20,18 @@ import time
 
 
 class _TestSession:
-    def __init__(self, *args, **kwargs) -> None:  # pylint: disable=super-init-not-called,unused-argument
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called,unused-argument
         self.post_called: List[Tuple[Any, ...]] = list()
 
-    def post(self, *args, **kwargs) -> None:
+    def post(self, *args: Any, **kwargs: Any) -> None:
         self.post_called.append((args, kwargs))
 
     def __enter__(self) -> None:
         pass
 
-    def __exit__(self, type, value, traceback) -> None:  # pylint: disable=redefined-builtin
+    def __exit__(
+        self, type: Type[BaseException], value: BaseException, traceback: TracebackType
+    ) -> None:  # pylint: disable=redefined-builtin
         pass
 
 

--- a/test/notifier/test_interface.py
+++ b/test/notifier/test_interface.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 
 class _TestNotifier(Notifier):
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.object_created_called = 0
         self.object_deleted_called = 0

--- a/test/notifier/test_interface.py
+++ b/test/notifier/test_interface.py
@@ -1,6 +1,6 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
 from rohmu.notifier.interface import Notifier
-from typing import Optional
+from typing import Any, Optional
 
 
 class _TestNotifier(Notifier):
@@ -10,7 +10,7 @@ class _TestNotifier(Notifier):
         self.object_deleted_called = 0
         self.tree_deleted_called = 0
 
-    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict]) -> None:
+    def object_created(self, key: str, size: Optional[int], metadata: Optional[dict[str, str]]) -> None:
         self.object_created_called += 1
 
     def object_deleted(self, key: str) -> None:

--- a/test/notifier/test_interface.py
+++ b/test/notifier/test_interface.py
@@ -1,4 +1,7 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+
+from __future__ import annotations
+
 from rohmu.notifier.interface import Notifier
 from typing import Any, Optional
 

--- a/test/test_atomic_opener.py
+++ b/test/test_atomic_opener.py
@@ -7,24 +7,24 @@ import pytest
 import time
 
 
-def _verify_file_not_created_and_dir_not_polluted(output_file: Path):
+def _verify_file_not_created_and_dir_not_polluted(output_file: Path) -> None:
     assert os.listdir(output_file.parent) == []
     assert not output_file.exists()
 
 
-def test_error_thrown_if_final_path_parent_doesnt_exist(tmp_path: Path):
+def test_error_thrown_if_final_path_parent_doesnt_exist(tmp_path: Path) -> None:
     with pytest.raises(IOError):
         with atomic_opener(tmp_path / "nonexistingdir" / "final_path", mode="w"):
             pass
 
 
-def test_error_mode_doesnt_contain_write(tmp_path: Path):
+def test_error_mode_doesnt_contain_write(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
         with atomic_opener(tmp_path, mode="r"):  # type: ignore
             pass
 
 
-def test_file_is_atomically_created_only_after_function_execution_is_over(tmp_path: Path):
+def test_file_is_atomically_created_only_after_function_execution_is_over(tmp_path: Path) -> None:
     data_block = "x" * 100_000_000
     # manually tested with block_count of 1000 but it seems overkill to do it every time and it can hog
     # the testing infra quite a bit.
@@ -59,7 +59,7 @@ def test_file_is_atomically_created_only_after_function_execution_is_over(tmp_pa
             pass
 
 
-def test_file_is_never_created_if_function_breaks(tmp_path: Path):
+def test_file_is_never_created_if_function_breaks(tmp_path: Path) -> None:
     output_file = tmp_path / "something"
 
     try:
@@ -77,7 +77,7 @@ def test_file_is_never_created_if_function_breaks(tmp_path: Path):
         _verify_file_not_created_and_dir_not_polluted(output_file)
 
 
-def test_file_is_fully_written_if_visible(tmp_path: Path):
+def test_file_is_fully_written_if_visible(tmp_path: Path) -> None:
     output_file = tmp_path / "something"
 
     def linkhook():
@@ -97,21 +97,21 @@ def test_file_is_fully_written_if_visible(tmp_path: Path):
         _verify_file_not_created_and_dir_not_polluted(output_file)
 
 
-def test_open_for_writing_text_opens_proper_encoding_file(tmp_path: Path):
+def test_open_for_writing_text_opens_proper_encoding_file(tmp_path: Path) -> None:
     final_path = tmp_path / "file"
     with atomic_opener(final_path, encoding="iso-8859-1", mode="w") as f:
         f.write("à")
     assert final_path.read_bytes() == b"\xe0"
 
 
-def test_open_for_writing_bytes_properly_writes_bytes(tmp_path: Path):
+def test_open_for_writing_bytes_properly_writes_bytes(tmp_path: Path) -> None:
     final_path = tmp_path / "file"
     with atomic_opener(final_path, mode="wb") as f:
         f.write(b"\xe0")
     assert final_path.read_text("iso-8859-1") == "à"
 
 
-def test_no_fd_leak_if_fdopen_fails_because_of_wrong_encoding(tmp_path: Path):
+def test_no_fd_leak_if_fdopen_fails_because_of_wrong_encoding(tmp_path: Path) -> None:
     final_path = tmp_path / "file"
     opened_fd: list[int] = []
     try:
@@ -128,7 +128,7 @@ def test_no_fd_leak_if_fdopen_fails_because_of_wrong_encoding(tmp_path: Path):
             # descriptor is invalid, all ok
 
 
-def test_no_fd_leak_if_fdopen_fails_because_of_unknown_mode(tmp_path: Path):
+def test_no_fd_leak_if_fdopen_fails_because_of_unknown_mode(tmp_path: Path) -> None:
     final_path = tmp_path / "file"
     opened_fd: list[int] = []
     try:

--- a/test/test_atomic_opener.py
+++ b/test/test_atomic_opener.py
@@ -80,7 +80,7 @@ def test_file_is_never_created_if_function_breaks(tmp_path: Path) -> None:
 def test_file_is_fully_written_if_visible(tmp_path: Path) -> None:
     output_file = tmp_path / "something"
 
-    def linkhook():
+    def linkhook() -> None:
         assert output_file.exists()
         assert output_file.read_text() == "aaaaaaaaaa"
 

--- a/test/test_atomic_opener.py
+++ b/test/test_atomic_opener.py
@@ -20,7 +20,7 @@ def test_error_thrown_if_final_path_parent_doesnt_exist(tmp_path: Path) -> None:
 
 def test_error_mode_doesnt_contain_write(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
-        with atomic_opener(tmp_path, mode="r"):  # type: ignore
+        with atomic_opener(tmp_path, mode="r"):  # type: ignore [call-overload]
             pass
 
 

--- a/test/test_compressor.py
+++ b/test/test_compressor.py
@@ -1,0 +1,25 @@
+from rohmu.compressor import CompressionFile, DecompressionFile
+
+import io
+import pytest
+
+
+@pytest.mark.parametrize(
+    "algorithm,contents",
+    [
+        ("lzma", b""),
+        ("snappy", b""),
+        ("lzma", b"Some contents"),
+        ("snappy", b"Some contents"),
+    ],
+)
+def test_compress_decompress_simple_file(algorithm: str, contents: bytes) -> None:
+    bio = io.BytesIO()
+    ef = CompressionFile(bio, algorithm=algorithm)
+    ef.write(contents)
+    ef.close()
+    bio.seek(0)
+
+    df = DecompressionFile(bio, algorithm=algorithm)
+    data = df.read()
+    assert data == contents

--- a/test/test_dates.py
+++ b/test/test_dates.py
@@ -11,7 +11,7 @@ import dateutil.tz
 import re
 
 
-def test_parse_timestamp():
+def test_parse_timestamp() -> None:
     local_aware = datetime.datetime.now(dateutil.tz.tzlocal())
 
     # split local_aware such as "2021-02-08T09:58:27.988218-05:00" into date, time, tzoffset components

--- a/test/test_encryptor.py
+++ b/test/test_encryptor.py
@@ -1,3 +1,4 @@
+# type: ignore
 """
 Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details

--- a/test/test_encryptor.py
+++ b/test/test_encryptor.py
@@ -1,11 +1,12 @@
-# type: ignore
 """
 Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
 from .base import CONSTANT_TEST_RSA_PRIVATE_KEY, CONSTANT_TEST_RSA_PUBLIC_KEY
+from py.path import LocalPath  # type: ignore [import] # pylint: disable=import-error
 from rohmu import IO_BLOCK_SIZE
 from rohmu.encryptor import Decryptor, DecryptorFile, Encryptor, EncryptorFile, EncryptorStream
+from typing import cast, IO
 
 import io
 import json
@@ -15,7 +16,7 @@ import random
 import tarfile
 
 
-def test_encryptor_decryptor():
+def test_encryptor_decryptor() -> None:
     plaintext = b"test"
     for op in (None, "json"):
         if op == "json":
@@ -40,7 +41,7 @@ def test_encryptor_decryptor():
         assert plaintext == decrypted
 
 
-def test_encryptor_stream():
+def test_encryptor_stream() -> None:
     plaintext = os.urandom(2 * 1024 * 1024)
     encrypted_stream = EncryptorStream(io.BytesIO(plaintext), CONSTANT_TEST_RSA_PUBLIC_KEY)
     result_data = io.BytesIO()
@@ -69,7 +70,7 @@ def test_encryptor_stream():
     assert plaintext == decrypted
 
 
-def test_decryptorfile(tmpdir):
+def test_decryptorfile(tmpdir: LocalPath) -> None:
     # create a plaintext blob bigger than IO_BLOCK_SIZE
     plaintext1 = b"rvdmfki6iudmx8bb25tx1sozex3f4u0nm7uba4eibscgda0ckledcydz089qw1p1wer"
     repeat = int(1.5 * IO_BLOCK_SIZE / len(plaintext1))
@@ -143,7 +144,7 @@ def test_decryptorfile(tmpdir):
         fp.truncate()
 
 
-def test_decryptorfile_for_tarfile(tmpdir):
+def test_decryptorfile_for_tarfile(tmpdir: LocalPath) -> None:
     testdata = b"file contents"
     data_tmp_name = tmpdir.join("plain.data").strpath
     with open(data_tmp_name, mode="wb") as data_tmp:
@@ -162,13 +163,14 @@ def test_decryptorfile_for_tarfile(tmpdir):
         enc_tar.seek(0)
 
         dfile = DecryptorFile(enc_tar, CONSTANT_TEST_RSA_PRIVATE_KEY)
-        with tarfile.open(fileobj=dfile, mode="r") as tar:
+        with tarfile.open(fileobj=cast(IO[bytes], dfile), mode="r") as tar:
             info = tar.getmember("archived_content")
             assert info.isfile() is True
             assert info.size == len(testdata)
             content_file = tar.extractfile("archived_content")
-            content = content_file.read()  # pylint: disable=no-member
-            content_file.close()  # pylint: disable=no-member
+            assert content_file is not None
+            content = content_file.read()
+            content_file.close()
             assert testdata == content
 
             decout = tmpdir.join("dec_out_dir").strpath
@@ -179,7 +181,7 @@ def test_decryptorfile_for_tarfile(tmpdir):
                 assert testdata == ext_fp.read()
 
 
-def test_encryptorfile(tmpdir):
+def test_encryptorfile(tmpdir: LocalPath) -> None:
     # create a plaintext blob bigger than IO_BLOCK_SIZE
     plaintext1 = b"rvdmfki6iudmx8bb25tx1sozex3f4u0nm7uba4eibscgda0ckledcydz089qw1p1"
     repeat = int(1.5 * IO_BLOCK_SIZE / len(plaintext1))
@@ -219,7 +221,7 @@ def test_encryptorfile(tmpdir):
         assert plaintext == result
 
 
-def test_encryptorfile_for_tarfile(tmpdir):
+def test_encryptorfile_for_tarfile(tmpdir: LocalPath) -> None:
     testdata = b"file contents"
     data_tmp_name = tmpdir.join("plain.data").strpath
     with open(data_tmp_name, mode="wb") as data_tmp:
@@ -228,24 +230,25 @@ def test_encryptorfile_for_tarfile(tmpdir):
     enc_tar_name = tmpdir.join("enc.tar.data").strpath
     with open(enc_tar_name, "w+b") as plain_fp:
         enc_fp = EncryptorFile(plain_fp, CONSTANT_TEST_RSA_PUBLIC_KEY)
-        with tarfile.open(name="foo", fileobj=enc_fp, mode="w") as tar:
+        with tarfile.open(name="foo", fileobj=cast(IO[bytes], enc_fp), mode="w") as tar:
             tar.add(data_tmp_name, arcname="archived_content")
         enc_fp.close()
 
         plain_fp.seek(0)
 
         dfile = DecryptorFile(plain_fp, CONSTANT_TEST_RSA_PRIVATE_KEY)
-        with tarfile.open(fileobj=dfile, mode="r") as tar:
+        with tarfile.open(fileobj=cast(IO[bytes], dfile), mode="r") as tar:
             info = tar.getmember("archived_content")
             assert info.isfile() is True
             assert info.size == len(testdata)
             content_file = tar.extractfile("archived_content")
-            content = content_file.read()  # pylint: disable=no-member
-            content_file.close()  # pylint: disable=no-member
+            assert content_file is not None
+            content = content_file.read()
+            content_file.close()
             assert testdata == content
 
 
-def test_empty_file():
+def test_empty_file() -> None:
     bio = io.BytesIO()
     ef = EncryptorFile(bio, CONSTANT_TEST_RSA_PUBLIC_KEY)
     ef.write(b"")

--- a/test/test_from_model.py
+++ b/test/test_from_model.py
@@ -1,5 +1,5 @@
-from rohmu import get_class_for_transfer, get_transfer
-from unittest.mock import MagicMock, patch
+from rohmu import Config, get_class_for_transfer, get_transfer
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import sys
@@ -19,15 +19,16 @@ import sys
 @patch("rohmu.notifier.http.BackgroundHTTPNotifier")
 @patch("rohmu.object_storage.s3.S3Transfer.from_model")
 @patch("rohmu.object_storage.s3.S3Transfer.config_model")
-def test_get_transfer(mock_config_model, mock_from_model, mock_notifier, config):
+def test_get_transfer(mock_config_model: Mock, mock_from_model: Mock, mock_notifier: Mock, config: Config) -> None:
     _transfer = get_transfer(config)
-    config.pop("storage_type")
-    config.pop("notifier")
-    mock_config_model.assert_called_once_with(**config, notifier=mock_notifier())
+    expected_config_arg = dict(config)
+    expected_config_arg.pop("storage_type")
+    expected_config_arg.pop("notifier")
+    mock_config_model.assert_called_once_with(**expected_config_arg, notifier=mock_notifier())
     mock_from_model.assert_called_once_with(mock_config_model())
 
 
 @pytest.mark.parametrize("storage_type", ["s3", "local", "azure", "google", "swift", "s3"])
 @patch.dict(sys.modules, {"swiftclient": MagicMock(), "azure.common": MagicMock()})
-def test_config_model_defined(storage_type):
+def test_config_model_defined(storage_type: str) -> None:
     assert get_class_for_transfer({"storage_type": storage_type}).config_model

--- a/test/test_inotify.py
+++ b/test/test_inotify.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from rohmu.inotify import parse_inotify_buffer
+
+import pytest
+import struct
+
+
+def _make_buffer(wd: int, mask: int, cookie: int, name: bytes) -> bytes:
+    return struct.pack("iIII", wd, mask, cookie, len(name)) + name
+
+
+@pytest.mark.parametrize(
+    "buffer,result",
+    [
+        (b"", []),
+        (_make_buffer(1, 2, 3, b"Hello, World!"), [(1, 2, 3, b"Hello, World!")]),
+        (
+            _make_buffer(11, 12, 13, b"Hello, ") + _make_buffer(101, 102, 103, b"World!"),
+            [(11, 12, 13, b"Hello, "), (101, 102, 103, b"World!")],
+        ),
+    ],
+)
+def test_parse_inotify_buffer(buffer: bytes, result: list[tuple[int, int, int, bytes]]) -> None:
+    got = list(parse_inotify_buffer(buffer))
+    assert got == result

--- a/test/test_object_storage_azure.py
+++ b/test/test_object_storage_azure.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from io import BytesIO
 from tempfile import NamedTemporaryFile
 from types import ModuleType
-from typing import Tuple
+from typing import Any, Tuple
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -72,7 +72,7 @@ def test_store_file_object(azure_module: ModuleType, get_blob_client: MagicMock)
     metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
     file_object = BytesIO(test_data)
 
-    def upload_side_effect(*args, **kwargs):  # pylint: disable=unused-argument
+    def upload_side_effect(*args: Any, **kwargs: Any) -> None:  # pylint: disable=unused-argument
         if kwargs.get("raw_response_hook"):
             kwargs["raw_response_hook"](MagicMock(context={"upload_stream_current": len(test_data)}))
 

--- a/test/test_object_storage_azure.py
+++ b/test/test_object_storage_azure.py
@@ -27,12 +27,12 @@ def fixture_mock_azure_module() -> Tuple[ModuleType, MagicMock]:
 
 
 @pytest.fixture(name="azure_module")
-def fixture_azure_module(mock_azure_module) -> ModuleType:
+def fixture_azure_module(mock_azure_module: Tuple[ModuleType, MagicMock]) -> ModuleType:
     return mock_azure_module[0]
 
 
 @pytest.fixture(name="get_blob_client")
-def fixture_get_blob_client(mock_azure_module) -> MagicMock:
+def fixture_get_blob_client(mock_azure_module: Tuple[ModuleType, MagicMock]) -> MagicMock:
     return mock_azure_module[1]
 
 

--- a/test/test_object_storage_s3.py
+++ b/test/test_object_storage_s3.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from rohmu.common.models import StorageOperation
 from rohmu.object_storage.s3 import S3Transfer
 from tempfile import NamedTemporaryFile
-from typing import Optional
+from typing import Any, Iterator, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -20,7 +20,7 @@ class S3Infra:
 
 
 @pytest.fixture(name="infra")
-def fixture_infra(mocker):
+def fixture_infra(mocker: Any) -> Iterator[S3Infra]:
     notifier = MagicMock()
     get_session = mocker.patch("botocore.session.get_session")
     s3_client = MagicMock()

--- a/test/test_object_storage_s3.py
+++ b/test/test_object_storage_s3.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from rohmu.common.models import StorageOperation
 from rohmu.object_storage.s3 import S3Transfer
 from tempfile import NamedTemporaryFile
+from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -35,7 +36,7 @@ def fixture_infra(mocker):
     yield S3Infra(notifier, operation, s3_client, transfer)
 
 
-def test_store_file_from_disk(infra) -> None:
+def test_store_file_from_disk(infra: S3Infra) -> None:
     test_data = b"test-data"
     metadata = {"Content-Length": len(test_data), "some-date": datetime(2022, 11, 15, 18, 30, 58, 486644)}
     with NamedTemporaryFile() as tmpfile:
@@ -55,7 +56,7 @@ def test_store_file_from_disk(infra) -> None:
 
 
 @pytest.mark.parametrize("multipart", [False, None, True])
-def test_store_file_object(infra, multipart) -> None:
+def test_store_file_object(infra: S3Infra, multipart: Optional[bool]) -> None:
     test_data = b"test-data"
     file_object = BytesIO(test_data)
 
@@ -92,7 +93,7 @@ def test_store_file_object(infra, multipart) -> None:
         )
 
 
-def test_operations_reporting(infra) -> None:
+def test_operations_reporting(infra: S3Infra) -> None:
     infra.operation.assert_called_once_with(StorageOperation.head_request)  # pylint: disable=no-member
 
 

--- a/test/test_object_storage_sftp.py
+++ b/test/test_object_storage_sftp.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from io import BytesIO
 from rohmu.object_storage.sftp import SFTPTransfer
 from tempfile import NamedTemporaryFile
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 
@@ -10,13 +11,13 @@ def test_store_file_from_disk() -> None:
     notifier = MagicMock()
     with patch("paramiko.Transport") as _, patch("paramiko.SFTPClient") as sftp_client:
 
-        def _putfo():
+        def _putfo() -> int:
             return 42
 
         client = MagicMock()
 
         # Size reporting relies on the progress callback from paramiko
-        def upload_side_effect(*args, **kwargs):  # pylint: disable=unused-argument
+        def upload_side_effect(*args: Any, **kwargs: Any) -> None:  # pylint: disable=unused-argument
             if kwargs.get("callback"):
                 kwargs["callback"](len(test_data), len(test_data))
 
@@ -59,7 +60,7 @@ def test_store_file_object() -> None:
         file_object = BytesIO(test_data)
 
         # Size reporting relies on the progress callback from paramiko
-        def upload_side_effect(*args, **kwargs):  # pylint: disable=unused-argument
+        def upload_side_effect(*args: Any, **kwargs: Any) -> None:  # pylint: disable=unused-argument
             if kwargs.get("callback"):
                 kwargs["callback"](len(test_data), len(test_data))
 

--- a/test/test_rohmu_dates.py
+++ b/test/test_rohmu_dates.py
@@ -11,7 +11,7 @@ import dateutil.tz
 import re
 
 
-def test_parse_timestamp():
+def test_parse_timestamp() -> None:
     local_aware = datetime.datetime.now(dateutil.tz.tzlocal())
 
     # split local_aware such as "2021-02-08T09:58:27.988218-05:00" into date, time, tzoffset components

--- a/test/test_rohmufile.py
+++ b/test/test_rohmufile.py
@@ -4,30 +4,31 @@ from io import BytesIO
 from rohmu import rohmufile
 from rohmu.errors import InvalidConfigurationError
 from tempfile import NamedTemporaryFile
+from typing import Any
 
 import pytest
 
 
-def test_fileobj_name(tmpdir):
+def test_fileobj_name(tmpdir: Any) -> None:
     with NamedTemporaryFile(dir=tmpdir, suffix="foo") as raw_output_obj:
-        result = rohmufile._fileobj_name(raw_output_obj)  # pylint: disable=protected-access
+        result = rohmufile._fileobj_name(raw_output_obj)  # type: ignore # pylint: disable=protected-access
         assert result.startswith("open file ")
         assert "foo" in result
 
 
-def test_get_encryption_key_data_no_metadata():
+def test_get_encryption_key_data_no_metadata() -> None:
     assert rohmufile._get_encryption_key_data(None, None) is None  # pylint: disable=protected-access
     assert rohmufile._get_encryption_key_data({}, None) is None  # pylint: disable=protected-access
 
 
-def test_get_encryption_key_data_invalid_configuration():
+def test_get_encryption_key_data_invalid_configuration() -> None:
     metadata = {"encryption-key-id": "foo"}
     with pytest.raises(InvalidConfigurationError, match="File is encrypted with key 'foo' but key not found"):
         rohmufile._get_encryption_key_data(metadata, lambda key_id: None)  # pylint: disable=protected-access
 
 
-def test_get_encryption_key_data():
-    def _getkey(key_id):
+def test_get_encryption_key_data() -> None:
+    def _getkey(key_id: str) -> str:
         assert key_id == "foo"
         return "bar"
 
@@ -36,19 +37,19 @@ def test_get_encryption_key_data():
     assert key_data == "bar"
 
 
-def test_file_reader_no_metadata():
+def test_file_reader_no_metadata() -> None:
     fileobj = BytesIO(b"foo")
     assert rohmufile.file_reader(fileobj=fileobj) == fileobj
 
 
-def test_file_reader_no_key():
+def test_file_reader_no_key() -> None:
     fileobj = BytesIO(b"foo")
     metadata = {"encryption-key-id": "foo"}
     with pytest.raises(InvalidConfigurationError, match="File is encrypted with key 'foo' but key not found"):
         rohmufile.file_reader(fileobj=fileobj, metadata=metadata)
 
 
-def test_file_reader_no_encryption_compression():
+def test_file_reader_no_encryption_compression() -> None:
     fileobj = BytesIO(b"foo")
     metadata = {"a": "b"}
     assert rohmufile.file_reader(fileobj=fileobj, metadata=metadata) == fileobj

--- a/test/test_statsd.py
+++ b/test/test_statsd.py
@@ -26,9 +26,9 @@ class _Protocol(asyncio.DatagramProtocol):
 
 
 @pytest.mark.asyncio
-async def test_statsd():
+async def test_statsd() -> None:
     loop = asyncio.get_running_loop()
-    received = asyncio.Queue()
+    received: asyncio.Queue[bytes] = asyncio.Queue()
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.bind(("", 0))

--- a/test/test_statsd.py
+++ b/test/test_statsd.py
@@ -18,7 +18,7 @@ import socket
 
 
 class _Protocol(asyncio.DatagramProtocol):
-    def __init__(self, queue: asyncio.Queue):
+    def __init__(self, queue: asyncio.Queue[bytes]):
         self.received_queue = queue
 
     def datagram_received(self, data: bytes, addr: tuple[str | Any, int]) -> None:

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -2,6 +2,8 @@ from datetime import datetime
 from io import BytesIO
 from pathlib import Path
 from rohmu import errors
+from rohmu.object_storage.local import LocalTransfer
+from typing import Any
 
 import pytest
 
@@ -9,9 +11,9 @@ DUMMY_CONTENT = b"dummy"
 DUMMY_METADATA = {"Content-Length": str(len(DUMMY_CONTENT))}
 
 
-@pytest.mark.parametrize("transfer", ["local_transfer"])
-def test_nonexistent(transfer, request):
-    transfer = request.getfixturevalue(transfer)
+@pytest.mark.parametrize("transfer_type", ["local_transfer"])
+def test_nonexistent(transfer_type: str, request: Any) -> None:
+    transfer = request.getfixturevalue(transfer_type)
     with pytest.raises(errors.FileNotFoundFromStorageError):
         transfer.get_metadata_for_key("NONEXISTENT")
     with pytest.raises(errors.FileNotFoundFromStorageError):
@@ -26,11 +28,11 @@ def test_nonexistent(transfer, request):
     assert transfer.list_path("NONEXISTENT") == []
 
 
-@pytest.mark.parametrize("transfer", ["local_transfer"])
-def test_basic_upload(transfer, tmp_path, request):
+@pytest.mark.parametrize("transfer_type", ["local_transfer"])
+def test_basic_upload(transfer_type: str, tmp_path: Path, request: Any) -> None:
     scratch = tmp_path / "scratch"
     scratch.mkdir()
-    transfer = request.getfixturevalue(transfer)
+    transfer = request.getfixturevalue(transfer_type)
     sent_metadata = {"k": "v"}
     metadata = DUMMY_METADATA.copy()
     metadata.update(sent_metadata)
@@ -52,9 +54,9 @@ def test_basic_upload(transfer, tmp_path, request):
     assert out.getvalue() == DUMMY_CONTENT
 
 
-@pytest.mark.parametrize("transfer", ["local_transfer"])
-def test_copy(transfer, request):
-    transfer = request.getfixturevalue(transfer)
+@pytest.mark.parametrize("transfer_type", ["local_transfer"])
+def test_copy(transfer_type: str, request: Any) -> None:
+    transfer = request.getfixturevalue(transfer_type)
     sent_metadata = {"k": "v"}
     metadata = DUMMY_METADATA.copy()
     metadata.update(sent_metadata)
@@ -67,9 +69,9 @@ def test_copy(transfer, request):
     assert transfer.get_contents_to_string("dummy_copy_metadata") == (DUMMY_CONTENT, {"new_k": "new_v"})
 
 
-@pytest.mark.parametrize("transfer", ["local_transfer"])
-def test_list(transfer, request):
-    transfer = request.getfixturevalue(transfer)
+@pytest.mark.parametrize("transfer_type", ["local_transfer"])
+def test_list(transfer_type: str, request: Any) -> None:
+    transfer = request.getfixturevalue(transfer_type)
     assert transfer.list_path("") == []
 
     # Test with a single file at root
@@ -95,7 +97,7 @@ def test_list(transfer, request):
     assert set(f["name"] for f in files) == {"dummy", "dummydir/dummy"}
 
 
-def test_hidden_local_files(local_transfer):
+def test_hidden_local_files(local_transfer: LocalTransfer) -> None:
     """
     Local storage specific test.
     """


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

This PR enables various strict MyPy settings and adds/changes a lot of type hints to enable better typing support.

Some improvements can be added later on. For example, I/O typing is particularly messy in general. The current best practice would be to define a couple `Protocol`s and use that as arguments, why leaving the return types as concrete `io` classes. Unfortunately this is not simple because some stubs/library use the `typing.IO*` stuff which is not 100% compatible. Most Rohmu entities deal with `BufferedIOBase`, and so I took that as most general I/O thing, with a couple of `cast`s or `Union` in a few places where the `typing.IO` is inevitable.

<!-- Provide the issue number below if it exists. -->
Resolves: #13 

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

The API has not changed, except for the better types, but I expect that if you get a `TypeError` with the new version you probably have a bug. In a few places some plain attributes are now `@property`s, so they can't be set anymore.