### PR TITLE
Implement byte_range download

### DIFF
--- a/rohmu/errors.py
+++ b/rohmu/errors.py
@@ -35,4 +35,8 @@ class MaybeRecoverableError(Error):
 
 
 class UninitializedError(Error):
-    """Error trying to access an uninitialized resource."""
+    """Error trying to access an uninitialized resource"""
+
+
+class InvalidByteRangeError(Error):
+    """Error specifying a content-range in a request"""

--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -17,7 +17,7 @@ from .base import IncrementalProgressCallbackType, ProgressProportionCallbackTyp
 # pylint: disable=import-error, no-name-in-module
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.storage.blob import BlobServiceClient, ContentSettings
-from typing import Any, BinaryIO, Iterator, Optional, Tuple, Union,
+from typing import Any, BinaryIO, Iterator, Optional, Tuple, Union
 
 import azure.common
 import logging
@@ -254,7 +254,13 @@ class AzureTransfer(BaseTransfer[Config]):
 
         return int(content_range.split(" ", 1)[1].split("/", 1)[1])
 
-    def _stream_blob(self, key: str, fileobj: BinaryIO, byte_range: Optional[tuple[int, int]], progress_callback: ProgressProportionCallbackType) -> None:
+    def _stream_blob(
+        self,
+        key: str,
+        fileobj: BinaryIO,
+        byte_range: Optional[tuple[int, int]],
+        progress_callback: ProgressProportionCallbackType,
+    ) -> None:
         """Streams contents of given key to given fileobj. Data is read sequentially in chunks
         without any seeks. This requires duplicating some functionality of the Azure SDK, which only
         allows reading entire blob into memory at once or returning data from random offsets"""
@@ -300,6 +306,7 @@ class AzureTransfer(BaseTransfer[Config]):
         progress_callback: ProgressProportionCallbackType = None,
     ) -> Metadata:
         path = self.format_key_for_backend(key, remove_slash_prefix=True)
+        self._validate_byte_range(byte_range)
 
         self.log.debug("Starting to fetch the contents of: %r", path)
         try:

--- a/rohmu/object_storage/azure.py
+++ b/rohmu/object_storage/azure.py
@@ -17,7 +17,7 @@ from .base import IncrementalProgressCallbackType, ProgressProportionCallbackTyp
 # pylint: disable=import-error, no-name-in-module
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.storage.blob import BlobServiceClient, ContentSettings
-from typing import Any, BinaryIO, Iterator, Optional, Union
+from typing import Any, BinaryIO, Iterator, Optional, Tuple, Union,
 
 import azure.common
 import logging
@@ -229,6 +229,7 @@ class AzureTransfer(BaseTransfer[Config]):
                         "metadata": metadata,
                         "name": self.format_key_from_backend(item.name),
                         "size": item.size,
+                        "md5": item.etag.strip('"'),
                     },
                 )
 
@@ -253,21 +254,27 @@ class AzureTransfer(BaseTransfer[Config]):
 
         return int(content_range.split(" ", 1)[1].split("/", 1)[1])
 
-    def _stream_blob(self, key: str, fileobj: BinaryIO, progress_callback: ProgressProportionCallbackType) -> None:
+    def _stream_blob(self, key: str, fileobj: BinaryIO, byte_range: Optional[tuple[int, int]], progress_callback: ProgressProportionCallbackType) -> None:
         """Streams contents of given key to given fileobj. Data is read sequentially in chunks
         without any seeks. This requires duplicating some functionality of the Azure SDK, which only
         allows reading entire blob into memory at once or returning data from random offsets"""
         file_size = None
-        start_range = 0
+        start_range = byte_range[0] if byte_range else 0
         chunk_size = self.conn._config.max_chunk_get_size  # type: ignore [attr-defined] # pylint: disable=protected-access
         end_range = chunk_size - 1
         blob = self.conn.get_blob_client(self.container_name, key)
         while True:
             try:
                 # pylint: disable=protected-access
-                download_stream = blob.download_blob(offset=start_range, length=chunk_size)
+                if byte_range:
+                    length = min(byte_range[1] - start_range + 1, chunk_size)
+                else:
+                    length = chunk_size
+                download_stream = blob.download_blob(offset=start_range, length=length)
                 if file_size is None:
                     file_size = download_stream._file_size
+                    if byte_range:
+                        file_size = min(file_size, byte_range[1] + 1)
                 download_stream.readinto(fileobj)
                 start_range += download_stream.size
                 if start_range >= file_size:
@@ -285,13 +292,18 @@ class AzureTransfer(BaseTransfer[Config]):
                 raise FileNotFoundFromStorageError(key) from ex
 
     def get_contents_to_fileobj(
-        self, key: str, fileobj_to_store_to: BinaryIO, *, progress_callback: ProgressProportionCallbackType = None
+        self,
+        key: str,
+        fileobj_to_store_to: BinaryIO,
+        *,
+        byte_range: Optional[Tuple[int, int]] = None,
+        progress_callback: ProgressProportionCallbackType = None,
     ) -> Metadata:
         path = self.format_key_for_backend(key, remove_slash_prefix=True)
 
         self.log.debug("Starting to fetch the contents of: %r", path)
         try:
-            self._stream_blob(path, fileobj_to_store_to, progress_callback)
+            self._stream_blob(path, fileobj_to_store_to, byte_range, progress_callback)
         except azure.core.exceptions.ResourceNotFoundError as ex:  # pylint: disable=no-member
             raise FileNotFoundFromStorageError(path) from ex
 

--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -15,7 +15,7 @@ from ..notifier.null import NullNotifier
 from ..typing import AnyPath, Metadata
 from contextlib import suppress
 from io import BytesIO
-from typing import Any, BinaryIO, Callable, Collection, Generic, Iterator, NamedTuple, Optional, Type, TypeVar, Union
+from typing import Any, BinaryIO, Callable, Collection, Generic, Iterator, NamedTuple, Optional, Tuple, Type, TypeVar, Union
 
 import logging
 import os
@@ -179,15 +179,25 @@ class BaseTransfer(Generic[StorageModelT]):
             raise
 
     def get_contents_to_fileobj(
-        self, key: str, fileobj_to_store_to: BinaryIO, *, progress_callback: ProgressProportionCallbackType = None
+        self,
+        key: str,
+        fileobj_to_store_to: BinaryIO,
+        *,
+        byte_range: Optional[Tuple[int, int]] = None,
+        progress_callback: ProgressProportionCallbackType = None
     ) -> Metadata:
         """Like `get_contents_to_file()` but writes to an open file-like object."""
         raise NotImplementedError
 
-    def get_contents_to_string(self, key: str) -> tuple[bytes, Metadata]:
-        """Returns a tuple (content-byte-string, metadata)"""
+    def get_contents_to_string(self, key, *, byte_range: Optional[Tuple[int, int]] = None):
+        """Returns a tuple (content-byte-string, metadata).
+
+        byte_range can be used to limit the content requested (as per RFC9110 section 14.1.2):
+        it defines range of bytes to fetch (inclusive), so e.g. [0, 499] means first 500 bytes.
+        If it is not supported for specific storage backend, NotImplementedError will be raised.
+        """
         with BytesIO() as buf:
-            metadata = self.get_contents_to_fileobj(key, buf)
+            metadata = self.get_contents_to_fileobj(key, buf, byte_range=byte_range)
             return buf.getvalue(), metadata
 
     def get_file_size(self, key: str) -> int:

--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -37,7 +37,7 @@ from googleapiclient.http import (
 from http.client import IncompleteRead
 from oauth2client import GOOGLE_TOKEN_URI
 from oauth2client.client import GoogleCredentials
-from typing import Any, BinaryIO, Callable, cast, Dict, Iterable, Iterator, Optional, TextIO, TypeVar, Union
+from typing import Any, BinaryIO, Callable, cast, Dict, Iterable, Iterator, Optional, TextIO, TypeVar, Union, Tuple
 
 import codecs
 import dataclasses
@@ -141,7 +141,7 @@ class Reporter:
     """
 
     operation: StorageOperation
-    size: Union[None, int] = None
+    size: Optional[int] = None
     progress_prev: int = 0
 
     def report(self, stats: StatsClient) -> None:
@@ -402,8 +402,19 @@ class GoogleTransfer(BaseTransfer[Config]):
             self.notifier.object_deleted(key)
 
     def get_contents_to_fileobj(
-        self, key: str, fileobj_to_store_to: BinaryIO, *, progress_callback: ProgressProportionCallbackType = None
+        self,
+        key: str,
+        fileobj_to_store_to: BinaryIO,
+        *,
+        byte_range: Optional[Tuple[int, int]] = None,
+        progress_callback: ProgressProportionCallbackType = None,
     ) -> Metadata:
+        if byte_range:
+            # TODO. The MediaIoBaseDownload has to be copied (it
+            # doesn't expose offset handling logic, or alternatively
+            # more recent Google client should be used.
+            raise NotImplementedError("byte range fetching not supported")
+
         path = self.format_key_for_backend(key)
         self.log.debug("Starting to fetch the contents of: %r to %r", path, fileobj_to_store_to)
         next_prog_report = 0.0

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -19,7 +19,7 @@ from .base import (
     ProgressProportionCallbackType,
 )
 from pathlib import Path
-from typing import Any, BinaryIO, Iterator, Optional, TextIO, Union
+from typing import Any, BinaryIO, Iterator, Optional, TextIO, Tuple, Union
 
 import contextlib
 import datetime
@@ -168,7 +168,12 @@ class LocalTransfer(BaseTransfer[Config]):
                 )
 
     def get_contents_to_fileobj(
-        self, key: str, fileobj_to_store_to: BinaryIO, *, progress_callback: ProgressProportionCallbackType = None
+        self,
+        key: str,
+        fileobj_to_store_to: BinaryIO,
+        *,
+        byte_range: Optional[Tuple[int, int]] = None,
+        progress_callback: ProgressProportionCallbackType = None,
     ) -> Metadata:
         source_path = self.format_key_for_backend(key.strip("/"))
         if not os.path.exists(source_path):
@@ -177,8 +182,12 @@ class LocalTransfer(BaseTransfer[Config]):
         input_size = os.stat(source_path).st_size
         bytes_written = 0
         with open(source_path, "rb") as fp:
-            while True:
-                buf = fp.read(CHUNK_SIZE)
+            if byte_range:
+                fp.seek(byte_range[0])
+                input_size = byte_range[1] - byte_range[0] + 1
+            while bytes_written <= input_size:
+                left = min(input_size - bytes_written, CHUNK_SIZE)
+                buf = fp.read(left)
                 if not buf:
                     break
                 fileobj_to_store_to.write(buf)

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -175,6 +175,7 @@ class LocalTransfer(BaseTransfer[Config]):
         byte_range: Optional[Tuple[int, int]] = None,
         progress_callback: ProgressProportionCallbackType = None,
     ) -> Metadata:
+        self._validate_byte_range(byte_range)
         source_path = self.format_key_for_backend(key.strip("/"))
         if not os.path.exists(source_path):
             raise FileNotFoundFromStorageError(key)

--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -276,7 +276,7 @@ class S3Transfer(BaseTransfer[Config]):
 
     def _get_object_stream(self, key: str, byte_range: Optional[tuple[int, int]]) -> tuple[StreamingBody, int, Metadata]:
         path = self.format_key_for_backend(key, remove_slash_prefix=True)
-        kwargs = {}
+        kwargs: dict[str, Any] = {}
         if byte_range:
             kwargs["Range"] = f"bytes {byte_range[0]}-{byte_range[1]}"
         try:
@@ -317,6 +317,7 @@ class S3Transfer(BaseTransfer[Config]):
         byte_range: Optional[Tuple[int, int]] = None,
         progress_callback: ProgressProportionCallbackType = None,
     ) -> Metadata:
+        self._validate_byte_range(byte_range)
         stream, length, metadata = self._get_object_stream(key, byte_range)
         self._read_object_to_fileobj(fileobj_to_store_to, stream, length, cb=progress_callback)
         return metadata

--- a/rohmu/object_storage/sftp.py
+++ b/rohmu/object_storage/sftp.py
@@ -21,7 +21,7 @@ from .base import (
 )
 from io import BytesIO
 from stat import S_ISDIR
-from typing import Any, BinaryIO, cast, Iterator, Optional
+from typing import cast, Any, BinaryIO, Iterator, Optional, Tuple
 
 import datetime
 import json
@@ -82,8 +82,15 @@ class SFTPTransfer(BaseTransfer[Config]):
         self.log.debug("SFTPTransfer initialized")
 
     def get_contents_to_fileobj(
-        self, key: str, fileobj_to_store_to: BinaryIO, *, progress_callback: ProgressProportionCallbackType = None
+        self,
+        key: str,
+        fileobj_to_store_to: BinaryIO,
+        *,
+        byte_range: Optional[Tuple[int, int]] = None,
+        progress_callback: ProgressProportionCallbackType = None,
     ) -> Metadata:
+        if byte_range:
+            raise NotImplementedError("byte range fetching not supported")
         self._get_contents_to_fileobj(key, fileobj_to_store_to, progress_callback)
         return self.get_metadata_for_key(key)
 

--- a/rohmu/object_storage/sftp.py
+++ b/rohmu/object_storage/sftp.py
@@ -21,7 +21,7 @@ from .base import (
 )
 from io import BytesIO
 from stat import S_ISDIR
-from typing import cast, Any, BinaryIO, Iterator, Optional, Tuple
+from typing import Any, BinaryIO, cast, Iterator, Optional, Tuple
 
 import datetime
 import json

--- a/rohmu/object_storage/swift.py
+++ b/rohmu/object_storage/swift.py
@@ -24,7 +24,7 @@ from .base import (
 )
 from contextlib import suppress
 from swiftclient import client, exceptions  # pylint: disable=import-error
-from typing import Any, BinaryIO, Iterator, Optional
+from typing import Any, BinaryIO, Iterator, Optional, Tuple
 
 import logging
 import os
@@ -235,8 +235,17 @@ class SwiftTransfer(BaseTransfer[Config]):
         self.notifier.object_deleted(key=key)
 
     def get_contents_to_fileobj(
-        self, key: str, fileobj_to_store_to: BinaryIO, *, progress_callback: ProgressProportionCallbackType = None
+        self,
+        key: str,
+        fileobj_to_store_to: BinaryIO,
+        *,
+        byte_range: Optional[Tuple[int, int]] = None,
+        progress_callback: ProgressProportionCallbackType = None,
     ) -> Metadata:
+        if byte_range:
+            # TODO if someday relevant. swift API itself implements it,
+            # c.f. https://docs.openstack.org/api-ref/object-store/
+            raise NotImplementedError("byte range fetching not supported")
         path = self.format_key_for_backend(key)
         try:
             headers, data_gen = self.conn.get_object(self.container_name, path, resp_chunk_size=CHUNK_SIZE)

--- a/rohmu/util.py
+++ b/rohmu/util.py
@@ -6,7 +6,7 @@ See LICENSE for details
 """
 from itertools import islice
 from rohmu.typing import HasFileno
-from typing import Generator, Iterable, Tuple, TypeVar, Union
+from typing import Generator, Iterable, Optional, Tuple, TypeVar, Union
 
 import fcntl
 import logging
@@ -65,3 +65,9 @@ def batched(iterable: Iterable[T], n: int) -> Generator[Tuple[T, ...], None, Non
     while batch:
         yield batch
         batch = tuple(islice(it, n))
+
+
+def get_total_size_from_content_range(content_range: str) -> Optional[int]:
+    length = content_range.rsplit("/", 1)[1]
+    # RFC 9110 section 14.4 specifies that the * can be returned when the total length is unknown
+    return int(length) if length != "*" else None

--- a/test/test_object_storage_google.py
+++ b/test/test_object_storage_google.py
@@ -1,12 +1,17 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
+from __future__ import annotations
+
 from contextlib import ExitStack
 from datetime import datetime
 from googleapiclient.http import MediaUploadProgress
 from io import BytesIO
 from rohmu.common.models import StorageOperation
-from rohmu.object_storage.google import GoogleTransfer, Reporter
+from rohmu.errors import InvalidByteRangeError
+from rohmu.object_storage.google import GoogleTransfer, MediaIoBaseDownloadWithByteRange, Reporter
 from tempfile import NamedTemporaryFile
-from unittest.mock import call, MagicMock, patch
+from unittest.mock import ANY, call, MagicMock, Mock, patch
+
+import pytest
 
 
 def test_store_file_from_memory() -> None:
@@ -120,3 +125,89 @@ def test_upload_size_unknown_to_reporter() -> None:
                 call(operation=StorageOperation.store_file, size=995),
             ]
         )
+
+
+def test_get_contents_to_fileobj_raises_error_on_invalid_byte_range() -> None:
+    notifier = MagicMock()
+    with ExitStack() as stack:
+        stack.enter_context(patch("rohmu.object_storage.google.get_credentials"))
+        stack.enter_context(patch("rohmu.object_storage.google.GoogleTransfer.get_or_create_bucket"))
+        transfer = GoogleTransfer(
+            project_id="test-project-id",
+            bucket_name="test-bucket",
+            notifier=notifier,
+        )
+        with pytest.raises(InvalidByteRangeError):
+            transfer.get_contents_to_fileobj(
+                key="testkey",
+                fileobj_to_store_to=BytesIO(),
+                byte_range=(100, 10),
+            )
+
+
+def _mock_request(calls: list[tuple[str, bytes]]) -> Mock:
+    results = []
+    for call_content_range, call_content in calls:
+        response = Mock()
+        response.status = 206
+        response.headers = {
+            "content-range": call_content_range,
+        }
+        response.__getitem__ = lambda self, key: self.headers[key]
+        response.__contains__ = lambda self, key: key in self.headers
+        results.append((response, call_content))
+    http_call = Mock(side_effect=lambda *args, **kwargs: results.pop(0))
+    request = Mock()
+    request.headers = {}
+    request.http.request = http_call
+    return request
+
+
+def test_media_io_download_with_byte_range() -> None:
+    mock_request = _mock_request([("3-8/13", b"lo, Wo")])
+    result = BytesIO()
+    download = MediaIoBaseDownloadWithByteRange(result, mock_request, byte_range=(3, 8))
+    status, done = download.next_chunk()
+    assert done
+    assert status.progress() == 1.0
+    assert result.getvalue() == b"lo, Wo"
+    mock_request.http.request.assert_called_once_with(ANY, ANY, headers={"range": "bytes=3-8"})
+
+
+def test_media_io_download_with_byte_range_and_tiny_chunks() -> None:
+    mock_request = _mock_request([("3-5/13", b"lo,"), ("6-8/13", b" Wo"), ("9-10/13", b"rl")])
+    result = BytesIO()
+    download = MediaIoBaseDownloadWithByteRange(result, mock_request, chunksize=3, byte_range=(3, 10))
+    status, done = download.next_chunk()
+    assert not done
+    assert status.progress() == 0.375
+    assert result.getvalue() == b"lo,"
+
+    status, done = download.next_chunk()
+    assert not done
+    assert status.progress() == 0.750
+    assert result.getvalue() == b"lo, Wo"
+
+    status, done = download.next_chunk()
+    assert done
+    assert status.progress() == 1.0
+    assert result.getvalue() == b"lo, Worl"
+
+    mock_request.http.request.assert_has_calls(
+        [
+            call(ANY, ANY, headers={"range": "bytes=3-5"}),
+            call(ANY, ANY, headers={"range": "bytes=6-8"}),
+            call(ANY, ANY, headers={"range": "bytes=9-10"}),
+        ]
+    )
+
+
+def test_media_io_download_with_byte_range_and_very_small_object() -> None:
+    mock_request = _mock_request([("3-13/13", b"lo, World!")])
+    result = BytesIO()
+    download = MediaIoBaseDownloadWithByteRange(result, mock_request, byte_range=(3, 100))
+    status, done = download.next_chunk()
+    assert done
+    assert status.progress() == 1.0
+    assert result.getvalue() == b"lo, World!"
+    mock_request.http.request.assert_called_once_with(ANY, ANY, headers={"range": "bytes=3-100"})

--- a/test/test_object_storage_local.py
+++ b/test/test_object_storage_local.py
@@ -1,10 +1,12 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
 from io import BytesIO
+from rohmu.errors import InvalidByteRangeError
 from rohmu.object_storage.local import LocalTransfer
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest.mock import MagicMock
 
 import os
+import pytest
 
 
 def test_store_file_from_disk() -> None:
@@ -49,3 +51,18 @@ def test_store_file_object() -> None:
 
         data, _ = transfer.get_contents_to_string("test_key2", byte_range=(0, len(test_data) - 2))
         assert data == test_data[:-1]
+
+
+def test_get_contents_to_fileobj_raises_error_on_invalid_byte_range() -> None:
+    with TemporaryDirectory() as destdir:
+        notifier = MagicMock()
+        transfer = LocalTransfer(
+            directory=destdir,
+            notifier=notifier,
+        )
+        with pytest.raises(InvalidByteRangeError):
+            transfer.get_contents_to_fileobj(
+                key="testkey",
+                fileobj_to_store_to=BytesIO(),
+                byte_range=(100, 10),
+            )

--- a/test/test_object_storage_local.py
+++ b/test/test_object_storage_local.py
@@ -40,3 +40,12 @@ def test_store_file_object() -> None:
 
         assert open(os.path.join(destdir, "test_key2"), "rb").read() == test_data
         notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data), metadata={})
+
+        data, _ = transfer.get_contents_to_string("test_key2")
+        assert data == test_data
+
+        data, _ = transfer.get_contents_to_string("test_key2", byte_range=(1, 123456))
+        assert data == test_data[1:]
+
+        data, _ = transfer.get_contents_to_string("test_key2", byte_range=(0, len(test_data) - 2))
+        assert data == test_data[:-1]

--- a/test/test_object_storage_s3.py
+++ b/test/test_object_storage_s3.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from io import BytesIO
 from rohmu.common.models import StorageOperation
+from rohmu.errors import InvalidByteRangeError
 from rohmu.object_storage.s3 import S3Transfer
 from tempfile import NamedTemporaryFile
 from typing import Any, Iterator, Optional
@@ -104,3 +105,13 @@ def test_deletion(infra: S3Infra) -> None:
     )
     infra.transfer.delete_key("1")
     infra.s3_client.delete_object.assert_called_once_with(Bucket="test-bucket", Key="test-prefix/1")
+
+
+def test_get_contents_to_fileobj_raises_error_on_invalid_byte_range(infra: S3Infra) -> None:
+    transfer = infra.transfer
+    with pytest.raises(InvalidByteRangeError):
+        transfer.get_contents_to_fileobj(
+            key="testkey",
+            fileobj_to_store_to=BytesIO(),
+            byte_range=(100, 10),
+        )

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -124,10 +124,10 @@ def test_hidden_local_files(local_transfer: LocalTransfer) -> None:
 
 
 @pytest.mark.parametrize("transfer", ["local_transfer"])
-def test_delete(transfer: LocalTransfer, request: Any):
+def test_delete(transfer: LocalTransfer, request: Any) -> None:
     transfer = request.getfixturevalue(transfer)
 
-    def setup():
+    def setup() -> None:
         assert transfer.list_path("") == []
         transfer.store_file_from_memory("shallow", b"1")
         transfer.store_file_from_memory("something/quite/deep", b"2")

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -123,21 +123,24 @@ def test_hidden_local_files(local_transfer: LocalTransfer) -> None:
     assert files[0]["name"] == "somefile"
 
 
-def test_delete(local_transfer: LocalTransfer) -> None:
-    def setup() -> None:
-        assert local_transfer.list_path("") == []
-        local_transfer.store_file_from_memory("shallow", b"1")
-        local_transfer.store_file_from_memory("something/quite/deep", b"2")
-        assert len(local_transfer.list_path("", deep=True)) == 2
+@pytest.mark.parametrize("transfer", ["local_transfer"])
+def test_delete(transfer: LocalTransfer, request: Any):
+    transfer = request.getfixturevalue(transfer)
+
+    def setup():
+        assert transfer.list_path("") == []
+        transfer.store_file_from_memory("shallow", b"1")
+        transfer.store_file_from_memory("something/quite/deep", b"2")
+        assert len(transfer.list_path("", deep=True)) == 2
 
     setup()
-    local_transfer.delete_tree("")
+    transfer.delete_tree("")
 
     setup()
-    local_transfer.delete_keys(["shallow", "something/quite/deep"])
+    transfer.delete_keys(["shallow", "something/quite/deep"])
 
     setup()
-    local_transfer.delete_key("shallow")
-    local_transfer.delete_key("something/quite/deep")
+    transfer.delete_key("shallow")
+    transfer.delete_key("something/quite/deep")
 
-    assert local_transfer.list_path("") == []
+    assert transfer.list_path("") == []

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,0 +1,17 @@
+from rohmu.util import get_total_size_from_content_range
+from typing import Optional
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "content_range,result",
+    [
+        ("0-100/100", 100),
+        ("50-55/100", 100),
+        ("0-100/*", None),
+        ("0-100/1", 1),
+    ],
+)
+def test_get_total_size_from_content_range(content_range: str, result: Optional[int]) -> None:
+    assert get_total_size_from_content_range(content_range) == result


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

It allows providing a byte_range for the method `get_contents_to_fileobj` of transfer classes.

# Why this way

Some APIs provide built-in support for this change, others do not.

For the Google implementation:
This PR uses a patched version of a googleapiclient class to add support to the byte_ranges.

I've looked a bit in the alternative of moving to google's cloud libraries, but to me it sounds like a lot of work and I don't see a simple way to use those just for the use-case of adding byte-range support so it would mean a rewrite of the whole google implementation from what I see.

BTW: I started from mst-dev branch but I rebased it on `main` fixing the conflicts, that's why there are some fingon's commits.