### PR TITLE
Support byte range download

### DIFF
--- a/rohmu/object_storage/google.py
+++ b/rohmu/object_storage/google.py
@@ -128,7 +128,7 @@ class Reporter:
     """
 
     operation: StorageOperation
-    size: Union[None, int] = None
+    size: Optional[int] = None
     progress_prev: int = 0
 
     def report(self, stats: StatsClient):
@@ -377,7 +377,20 @@ class GoogleTransfer(BaseTransfer[Config]):
             reporter.report(self.stats)
             self.notifier.object_deleted(key)
 
-    def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback: ProgressProportionCallbackType = None):
+    def get_contents_to_fileobj(
+        self,
+        key,
+        fileobj_to_store_to,
+        *,
+        byte_range: Optional[Tuple[int, int]] = None,
+        progress_callback: ProgressProportionCallbackType = None,
+    ):
+        if byte_range:
+            # TODO. The MediaIoBaseDownload has to be copied (it
+            # doesn't expose offset handling logic, or alternatively
+            # more recent Google client should be used.
+            raise NotImplementedError("byte range fetching not supported")
+
         path = self.format_key_for_backend(key)
         self.log.debug("Starting to fetch the contents of: %r to %r", path, fileobj_to_store_to)
         next_prog_report = 0.0

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -17,7 +17,7 @@ from .base import (
     KEY_TYPE_PREFIX,
     ProgressProportionCallbackType,
 )
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 
 import contextlib
 import datetime
@@ -155,7 +155,14 @@ class LocalTransfer(BaseTransfer[Config]):
                     with_metadata=with_metadata,
                 )
 
-    def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback: ProgressProportionCallbackType = None):
+    def get_contents_to_fileobj(
+        self,
+        key,
+        fileobj_to_store_to,
+        *,
+        byte_range: Optional[Tuple[int, int]] = None,
+        progress_callback: ProgressProportionCallbackType = None,
+    ):
         source_path = self.format_key_for_backend(key.strip("/"))
         if not os.path.exists(source_path):
             raise FileNotFoundFromStorageError(key)
@@ -163,8 +170,12 @@ class LocalTransfer(BaseTransfer[Config]):
         input_size = os.stat(source_path).st_size
         bytes_written = 0
         with open(source_path, "rb") as fp:
-            while True:
-                buf = fp.read(CHUNK_SIZE)
+            if byte_range:
+                fp.seek(byte_range[0])
+                input_size = byte_range[1] - byte_range[0] + 1
+            while bytes_written <= input_size:
+                left = min(input_size - bytes_written, CHUNK_SIZE)
+                buf = fp.read(left)
                 if not buf:
                     break
                 fileobj_to_store_to.write(buf)

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -21,12 +21,15 @@ from typing import Optional, Tuple, Union
 
 import contextlib
 import datetime
+import hashlib
 import json
 import os
 import shutil
 import tempfile
 
 CHUNK_SIZE = 1024 * 1024
+INTERNAL_METADATA_KEY_HASH = "_hash"
+INTERNAL_METADATA_KEYS = {INTERNAL_METADATA_KEY_HASH}
 
 
 class Config(StorageModel):
@@ -58,10 +61,12 @@ class LocalTransfer(BaseTransfer[Config]):
         if metadata is None:
             shutil.copy(source_path + ".metadata", destination_path + ".metadata")
         else:
-            self._save_metadata(destination_path, metadata)
+            new_metadata = self._filter_internal_metadata(self._get_metadata_for_key(source_key))
+            new_metadata.update(metadata)
+            self._save_metadata(destination_path, new_metadata)
         self.notifier.object_copied(key=destination_key, size=os.path.getsize(destination_path), metadata=metadata)
 
-    def get_metadata_for_key(self, key):
+    def _get_metadata_for_key(self, key):
         source_path = self.format_key_for_backend(key.strip("/"))
         if not os.path.exists(source_path):
             raise FileNotFoundFromStorageError(key)
@@ -71,6 +76,15 @@ class LocalTransfer(BaseTransfer[Config]):
                 return json.load(fp)
         except FileNotFoundError:
             raise FileNotFoundFromStorageError(key)
+
+    def _filter_internal_metadata(self, metadata):
+        return {key: value for key, value in metadata.items() if key in INTERNAL_METADATA_KEYS}
+
+    def _filter_metadata(self, metadata):
+        return {key: value for key, value in metadata.items() if key not in INTERNAL_METADATA_KEYS}
+
+    def get_metadata_for_key(self, key):
+        return self._filter_metadata(self._get_metadata_for_key(key))
 
     def delete_key(self, key: str) -> None:
         self.log.debug("Deleting key: %r", key)
@@ -98,16 +112,11 @@ class LocalTransfer(BaseTransfer[Config]):
     def _skip_file_name(file_name):
         return file_name.startswith(".") or file_name.endswith(".metadata") or ".metadata_tmp" in file_name
 
-    @staticmethod
-    def _yield_object(key, full_path, with_metadata):
-        metadata_file = full_path + ".metadata"
-        if not os.path.exists(metadata_file):
+    def _yield_object(self, key, full_path, with_metadata):
+        try:
+            metadata = self._get_metadata_for_key(key)
+        except FileNotFoundFromStorageError:
             return
-        if with_metadata:
-            with open(metadata_file, "r") as fp:
-                metadata = json.load(fp)
-        else:
-            metadata = None
         st = os.stat(full_path)
         last_modified = datetime.datetime.fromtimestamp(st.st_mtime, tz=datetime.timezone.utc)
         yield IterKeyItem(
@@ -116,7 +125,8 @@ class LocalTransfer(BaseTransfer[Config]):
                 "name": key,
                 "size": st.st_size,
                 "last_modified": last_modified,
-                "metadata": metadata,
+                "md5": metadata[INTERNAL_METADATA_KEY_HASH],
+                "metadata": self._filter_metadata(metadata) if with_metadata else None,
             },
         )
 
@@ -145,10 +155,6 @@ class LocalTransfer(BaseTransfer[Config]):
                 else:
                     yield IterKeyItem(type=KEY_TYPE_PREFIX, value=file_key)
             else:
-                # Don't return files if metadata file is not present; files are written in two phases and
-                # should be considered available only after also metadata has been written
-                if not os.path.exists(full_path + ".metadata"):
-                    continue
                 yield from self._yield_object(
                     key=os.path.join(key.strip("/"), file_name),
                     full_path=full_path,
@@ -210,18 +216,23 @@ class LocalTransfer(BaseTransfer[Config]):
         target_path = self.format_key_for_backend(key.strip("/"))
         os.makedirs(os.path.dirname(target_path), exist_ok=True)
         bytes_written = 0
+        m = hashlib.sha256()
         with open(target_path, "wb") as output_fp:
             while True:
                 data = fd.read(1024 * 1024)
                 if not data:
                     break
+                m.update(data)
                 output_fp.write(data)
                 bytes_written += len(data)
                 if upload_progress_fn:
                     upload_progress_fn(bytes_written)
-
+        metadata = metadata.copy() if metadata is not None else {}
+        metadata[INTERNAL_METADATA_KEY_HASH] = m.hexdigest()
         self._save_metadata(target_path, metadata)
-        self.notifier.object_created(key=key, size=os.path.getsize(target_path), metadata=self.sanitize_metadata(metadata))
+        self.notifier.object_created(
+            key=key, size=os.path.getsize(target_path), metadata=self.sanitize_metadata(self._filter_metadata(metadata))
+        )
 
 
 @contextlib.contextmanager

--- a/rohmu/object_storage/sftp.py
+++ b/rohmu/object_storage/sftp.py
@@ -20,7 +20,7 @@ from .base import (
 )
 from io import BytesIO, StringIO
 from stat import S_ISDIR
-from typing import cast, Optional, Union
+from typing import cast, Optional, Tuple, Union
 
 import datetime
 import json
@@ -80,7 +80,16 @@ class SFTPTransfer(BaseTransfer[Config]):
 
         self.log.debug("SFTPTransfer initialized")
 
-    def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback: ProgressProportionCallbackType = None):
+    def get_contents_to_fileobj(
+        self,
+        key,
+        fileobj_to_store_to,
+        *,
+        byte_range: Optional[Tuple[int, int]] = None,
+        progress_callback: ProgressProportionCallbackType = None,
+    ):
+        if byte_range:
+            raise NotImplementedError("byte range fetching not supported")
         self._get_contents_to_fileobj(key, fileobj_to_store_to, progress_callback)
         return self.get_metadata_for_key(key)
 

--- a/rohmu/object_storage/swift.py
+++ b/rohmu/object_storage/swift.py
@@ -20,7 +20,7 @@ from .base import (
 )
 from contextlib import suppress
 from swiftclient import client, exceptions  # pylint: disable=import-error
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 
 import logging
 import os
@@ -228,7 +228,18 @@ class SwiftTransfer(BaseTransfer[Config]):
             self._delete_object_plain(path)
         self.notifier.object_deleted(key=key)
 
-    def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback: ProgressProportionCallbackType = None):
+    def get_contents_to_fileobj(
+        self,
+        key,
+        fileobj_to_store_to,
+        *,
+        byte_range: Optional[Tuple[int, int]] = None,
+        progress_callback: ProgressProportionCallbackType = None,
+    ):
+        if byte_range:
+            # TODO if someday relevant. swift API itself implements it,
+            # c.f. https://docs.openstack.org/api-ref/object-store/
+            raise NotImplementedError("byte range fetching not supported")
         path = self.format_key_for_backend(key)
         try:
             headers, data_gen = self.conn.get_object(self.container_name, path, resp_chunk_size=CHUNK_SIZE)

--- a/test/test_object_storage_local.py
+++ b/test/test_object_storage_local.py
@@ -40,3 +40,12 @@ def test_store_file_object() -> None:
 
         assert open(os.path.join(destdir, "test_key2"), "rb").read() == test_data
         notifier.object_created.assert_called_once_with(key="test_key2", size=len(test_data), metadata={})
+
+        data, _ = transfer.get_contents_to_string("test_key2")
+        assert data == test_data
+
+        data, _ = transfer.get_contents_to_string("test_key2", byte_range=(1, 123456))
+        assert data == test_data[1:]
+
+        data, _ = transfer.get_contents_to_string("test_key2", byte_range=(0, len(test_data) - 2))
+        assert data == test_data[:-1]

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -106,7 +106,7 @@ def test_hidden_local_files(local_transfer):
     with open(Path(local_transfer.prefix) / ".null", "w"):
         pass
     with open(Path(local_transfer.prefix) / ".null.metadata", "w") as f:
-        f.write('{"k": "v"}')
+        f.write('{"k": "v", "_hash": ""}')
     assert local_transfer.list_path("") == []
 
     # Make sure the previous test actually worked, by manually creating a file
@@ -114,7 +114,7 @@ def test_hidden_local_files(local_transfer):
     with open(Path(local_transfer.prefix) / "somefile", "w"):
         pass
     with open(Path(local_transfer.prefix) / "somefile.metadata", "w") as f:
-        f.write('{"k": "v"}')
+        f.write('{"k": "v", "_hash": ""}')
 
     files = local_transfer.list_path("")
     assert len(files) == 1

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -119,3 +119,26 @@ def test_hidden_local_files(local_transfer):
     files = local_transfer.list_path("")
     assert len(files) == 1
     assert files[0]["name"] == "somefile"
+
+
+@pytest.mark.parametrize("transfer", ["local_transfer"])
+def test_delete(transfer, request):
+    transfer = request.getfixturevalue(transfer)
+
+    def setup():
+        assert transfer.list_path("") == []
+        transfer.store_file_from_memory("shallow", b"1")
+        transfer.store_file_from_memory("something/quite/deep", b"2")
+        assert len(transfer.list_path("", deep=True)) == 2
+
+    setup()
+    transfer.delete_tree("")
+
+    setup()
+    transfer.delete_keys(["shallow", "something/quite/deep"])
+
+    setup()
+    transfer.delete_key("shallow")
+    transfer.delete_key("something/quite/deep")
+
+    assert transfer.list_path("") == []


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

It allows providing a byte_range for downloading a range of an object.

# Why this way

This implementation messes with the internals of google's MediaIoBaseDownload, changing the progress and other fields to force the class to make the correct HTTP calls and also overrides how the status & done is computed.

This is an alternative PR to: https://github.com/aiven/rohmu/pull/109 .

