### PR TITLE
object_storage: remove boto3 dependency

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,8 +4,9 @@ mock
 mypy
 # Same version from pghoard
 pylint>=2.4.3,<=2.7.3
-boto3
-boto3-stubs[essential]
+botocore
+botocore-stubs[essential]
+mypy_boto3_s3
 pylint-quotes
 pytest
 pytest-cov

--- a/rohmu.spec
+++ b/rohmu.spec
@@ -8,7 +8,6 @@ Source0:        rohmu-rpm-src.tar
 Requires:       python3-azure-common
 Requires:       python3-azure-core
 Requires:       python3-azure-storage-blob
-Requires:       python3-boto3
 Requires:       python3-botocore
 Requires:       python3-cryptography >= 1.6
 Requires:       python3-dateutil


### PR DESCRIPTION
# About this change - What it does
Remove the boto3 dependency, there are no functional changes, 

# Why this way
The boto3 dependency is not needed, since we also use the botocore dependency. Additionally the boto3 dependency is more likely to result in dependency mismatches.

