### PR TITLE
object_storage: Ensure size is always an int

### DIFF
--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -108,7 +108,7 @@ class BaseTransfer(Generic[StorageModelT]):
             # We could actually sniff from fd if it is seekable; left TODO for now.
             return default
 
-        return size > chunk_size
+        return int(size) > chunk_size
 
     @classmethod
     def from_model(cls, model: StorageModelT) -> BaseTransfer[StorageModelT]:


### PR DESCRIPTION
In the case of OVH they are returning this value as str. Ensure this value is always an int

