### PR TITLE
implement transfer pooling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.10", "3.9", "3.8", "3.7"]
+        python-version: ["3.10", "3.9", "3.8"]
 
     steps:
       - id: checkout-code

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.7"
+        python-version: "3.8"
 
     - name: Ensure tags are properly synced
       run: git fetch --tags --force

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__/
 *.orig
 coverage.xml
 rohmu-rpm-src.tar
+.hypothesis/

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Features
 Requirements
 ============
 
-Rohmu requires Python >= 3.7. For Python library dependencies, have a
+Rohmu requires Python >= 3.8. For Python library dependencies, have a
 look at
 `requirements.txt <https://github.com/aiven/rohmu/blob/main/requirements.txt>`__.
 

--- a/rohmu/errors.py
+++ b/rohmu/errors.py
@@ -40,3 +40,7 @@ class UninitializedError(Error):
 
 class InvalidByteRangeError(Error):
     """Error specifying a content-range in a request"""
+
+
+class InvalidTransferError(Error):
+    """You tried to access a transfer object that you already returned to the pool"""

--- a/rohmu/object_storage/base.py
+++ b/rohmu/object_storage/base.py
@@ -51,6 +51,8 @@ StorageModelT = TypeVar("StorageModelT", bound=StorageModel)
 class BaseTransfer(Generic[StorageModelT]):
     config_model: Type[StorageModelT]
 
+    is_thread_safe: bool = False
+
     def __init__(
         self, prefix: Optional[str], notifier: Optional[Notifier] = None, statsd_info: Optional[StatsdConfig] = None
     ) -> None:

--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -42,6 +42,8 @@ class Config(StorageModel):
 class LocalTransfer(BaseTransfer[Config]):
     config_model = Config
 
+    is_thread_safe = True
+
     def __init__(
         self,
         directory: Union[str, Path],

--- a/rohmu/transfer_pool.py
+++ b/rohmu/transfer_pool.py
@@ -1,0 +1,219 @@
+"""
+rohmu - transfer_pool
+
+Copyright (c) 2023 Aiven, Helsinki, Finland. https://aiven.io/
+See LICENSE for details
+"""
+
+from __future__ import annotations
+
+from . import get_transfer as rohmu_get_transfer
+from .errors import InvalidTransferError
+from .object_storage.base import BaseTransfer, StorageModel
+from contextlib import contextmanager
+from typing import Any, Callable, Generator, Optional
+
+import heapq
+import json
+import logging
+import threading
+import time
+
+LOG = logging.getLogger(__name__)
+
+TRANSFER_MAX_AGE = 60 * 60 * 3
+TRANSFER_CACHE_MAX_AGE = TRANSFER_MAX_AGE * 2
+
+
+class TransferCacheItem:
+    create_time: float
+    cache_key: str
+    transfer: BaseTransfer[StorageModel]
+    max_age: float
+
+    def __init__(self, pool_key: str, transfer: BaseTransfer[StorageModel], max_age: float = TRANSFER_MAX_AGE) -> None:
+        self.create_time = time.monotonic()
+        self.cache_key = pool_key
+        self.transfer = transfer
+        self.max_age = max_age
+
+    def age(self) -> float:
+        return time.monotonic() - self.create_time
+
+    def is_expired(self) -> bool:
+        return self.age() > self.max_age
+
+    def __gt__(self, other: TransferCacheItem) -> bool:
+        """Ordering by creation time, needed for storing these in a heap."""
+        return self.create_time > other.create_time
+
+
+class _TransferCache:
+    transfers_heap: list[TransferCacheItem]
+    last_used: float
+    max_age: float
+
+    def __init__(self, max_age: float = TRANSFER_CACHE_MAX_AGE) -> None:
+        self.transfers_heap = []
+        self.last_used = time.monotonic()
+        self.max_age = max_age
+
+    def prune_expired(self) -> None:
+        while self.transfers_heap and self.transfers_heap[0].is_expired():
+            heapq.heappop(self.transfers_heap)
+
+    def get(self) -> Optional[TransferCacheItem]:
+        self.last_used = time.monotonic()
+        self.prune_expired()
+        if self.transfers_heap:
+            try:
+                return heapq.heappop(self.transfers_heap)
+            except IndexError:
+                pass
+        return None
+
+    def put(self, transfer: TransferCacheItem) -> None:
+        self.last_used = time.monotonic()
+        if not transfer.is_expired():
+            heapq.heappush(self.transfers_heap, transfer)
+
+    def age(self) -> float:
+        return time.monotonic() - self.last_used
+
+    def is_expired(self) -> bool:
+        return self.age() > self.max_age
+
+
+class _TransferCacheForThreadSafeTransfer(_TransferCache):
+    """This _TransferCache subclass is a simple implementation that works when the transfer is thread-safe.
+
+    In that case we can have a single instance and always return that one.
+
+    No expiration logic is applied to the transfer instance.
+    """
+
+    def __init__(self, transfer_item: TransferCacheItem, max_age: float = TRANSFER_CACHE_MAX_AGE) -> None:
+        super().__init__(max_age)
+        self.transfers_heap.append(transfer_item)
+
+    def get(self) -> Optional[TransferCacheItem]:
+        self.last_used = time.monotonic()
+        # there will always be only one transfer instance at most in this cache type
+        return self.transfers_heap[0]
+
+    def put(self, transfer: TransferCacheItem) -> None:
+        self.last_used = time.monotonic()
+
+
+_BASE_TRANSFER_INSTANCE_ATTRS = {"config_model", "log", "notifier", "prefix", "stats"}
+_BASE_TRANSFER_ATTRS = {attr for attr in vars(BaseTransfer) if not attr.startswith("__")} | _BASE_TRANSFER_INSTANCE_ATTRS
+
+# pylint: disable=abstract-method,super-init-not-called
+class SafeTransfer(BaseTransfer[StorageModel]):
+    """Helper class that helps the users in finding bugs in their code handling transfers.
+
+    This class prevents any call to a transfer instance that was returned to the pool.
+    It also logs a warning if the instance is garbage collected (returning it to the pool).
+
+    """
+
+    def __init__(self, item: TransferCacheItem, pool_reclaim: Callable[[TransferCacheItem], None]) -> None:
+        self._item = item
+        self._pool_reclaim = pool_reclaim
+        self._done = False
+
+    def __del__(self) -> None:
+        if not self._done:
+            LOG.warning("Transfer not marked as done was garbage collected. Returning it to the pool now.")
+
+    def __getattribute__(self, attr: str) -> Any:
+        if attr in _BASE_TRANSFER_ATTRS:
+            if self._done:
+                raise InvalidTransferError("Trying to access transfer instance already returned to the pool")
+            else:
+                return getattr(self._item.transfer, attr)
+        return super().__getattribute__(attr)
+
+    @classmethod
+    def from_model(cls, model: StorageModel) -> BaseTransfer[StorageModel]:
+        raise InvalidTransferError("You should not call class methods on SafeTransfer instances")
+
+    def return_to_pool(self) -> None:
+        """Return the underlying transfer instance to the pool.
+
+        After this call all uses of this transfer instance will raise InvalidTransferError.
+
+        This method can be called multiple times.
+        """
+        if self._done:
+            return
+        self._pool_reclaim(self._item)
+        self._done = True
+        del self._item
+
+
+class TransferPool:
+    def __init__(self, *, max_pool_age: float = TRANSFER_CACHE_MAX_AGE, max_transfer_age: float = TRANSFER_MAX_AGE):
+        self._max_pool_age = max_pool_age
+        self._max_transfer_age = max_transfer_age
+        self._caches: dict[str, _TransferCache] = {}
+        self._is_thread_safe: dict[str, bool] = {}
+        self._mutex = threading.Lock()
+
+    @contextmanager
+    def with_transfer(self, storage_config: dict[str, Any]) -> Generator[BaseTransfer[StorageModel], None, None]:
+        """Yield a transfer object according to the provided storage_config.
+
+        The transfer object may be created or cached. While the context manager is running the transfer object
+        won't be available to other threads.
+
+        Users of this contextmanager should NOT use the transfer object outside the `with` block
+        """
+        transfer = self._get(storage_config)
+        try:
+            yield transfer.transfer
+        finally:
+            self._put(transfer)
+
+    def get_transfer(self, storage_config: dict[str, Any]) -> SafeTransfer:
+        """Returns a transfer object.
+
+        The object returned is a proxy that will forward all accesses to the underlying transfer instance.
+        You MUST call `return_to_pool()` method once you are done with this transfer, and any access to the proxy
+        afterwards will raise an `InvalidTransferError`.
+
+        """
+        return SafeTransfer(item=self._get(storage_config), pool_reclaim=self._put)
+
+    def _prune_expired_caches(self) -> None:
+        self._caches = {key: pool for key, pool in self._caches.items() if not pool.is_expired()}
+
+    def _get(self, storage_config: dict[str, Any]) -> TransferCacheItem:
+        cache_key = _cache_key(storage_config)
+        with self._mutex:
+            if (cache := self._caches.get(cache_key)) and (cached_transfer := cache.get()):
+                return cached_transfer
+            transfer = rohmu_get_transfer(storage_config)
+            item = TransferCacheItem(cache_key, transfer, max_age=self._max_transfer_age)
+            if transfer.is_thread_safe:
+                self._caches[cache_key] = _TransferCacheForThreadSafeTransfer(item, max_age=self._max_pool_age)
+            else:
+                self._caches[cache_key] = _TransferCache(max_age=self._max_pool_age)
+
+            return item
+
+    def _put(self, transfer: TransferCacheItem) -> None:
+        with self._mutex:
+            transfer_pool = self._caches.get(transfer.cache_key)
+            if transfer_pool:
+                transfer_pool.put(transfer)
+            self._prune_expired_caches()
+
+
+def _cache_key(storage_config: dict[str, Any]) -> str:
+    return json.dumps(storage_config, sort_keys=True)
+
+
+DEFAULT_TRANSFER_POOL = TransferPool()
+with_transfer = DEFAULT_TRANSFER_POOL.with_transfer
+get_transfer = DEFAULT_TRANSFER_POOL.get_transfer

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ classifiers =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10

--- a/test/test_transfer_pool.py
+++ b/test/test_transfer_pool.py
@@ -1,0 +1,285 @@
+"""Copyright (c) 2023 Aiven, Helsinki, Finland. https://aiven.io/"""
+from dataclasses import dataclass
+from rohmu import transfer_pool
+from rohmu.errors import InvalidTransferError
+from rohmu.object_storage.local import LocalTransfer
+from unittest.mock import patch
+
+import pytest
+import time
+
+
+@dataclass(frozen=True)
+class FakeTransfer:
+    name: str
+    is_thread_safe: bool = False
+    # needed for safe transfer tests
+    prefix: str = "prefix"
+    notifier: str = "notifier"
+    stats: str = "stats"
+    config_model: str = "config_model"
+
+
+def test_transfer_pool() -> None:
+    """Test that a cached transfer object is returned, if available."""
+    storage_config_1 = {"storage_type": "azure"}
+    storage_config_2 = {"storage_type": "gcp"}
+
+    with patch("rohmu.transfer_pool.rohmu_get_transfer") as rohmu_get_transfer:
+        pool = transfer_pool.TransferPool()
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_1")
+        with pool.with_transfer(storage_config_1) as transfer:
+            rohmu_get_transfer.assert_called_once_with(storage_config_1)
+            assert transfer is not None
+
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_2")
+        with pool.with_transfer(storage_config_1) as next_transfer:
+            assert next_transfer == transfer
+            with pool.with_transfer(storage_config_2) as next_transfer_2:
+                assert next_transfer_2 is not None
+                assert next_transfer_2 != transfer
+
+
+def test_transfer_pool_context_manager_returns_transfer_on_exception() -> None:
+    """Test that a cached transfer object is returned, if available."""
+    storage_config_1 = {"storage_type": "azure"}
+
+    with patch("rohmu.transfer_pool.rohmu_get_transfer") as rohmu_get_transfer:
+        pool = transfer_pool.TransferPool()
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_1")
+        try:
+            with pool.with_transfer(storage_config_1) as transfer:
+                raise ValueError("Some error happens")
+        except ValueError:
+            pass
+
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_2")
+        with pool.with_transfer(storage_config_1) as next_transfer:
+            # the contextmanager should have returned the transfer to the pool, so we expect to get the same one
+            assert next_transfer == transfer
+
+
+def test_transfer_pool_expiration() -> None:
+    """Test that a cached transfer object is not returned, if too old."""
+    storage_config = {"storage_type": "azure"}
+
+    with patch("rohmu.transfer_pool.rohmu_get_transfer") as rohmu_get_transfer:
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_1")
+        pool = transfer_pool.TransferPool()
+
+        with pool.with_transfer(storage_config) as transfer:
+            # let's create an item
+            pass
+
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_2")
+        transfer_item = list(pool._caches.values())[0].transfers_heap[0]  # pylint: disable=protected-access
+        transfer_item.create_time = time.monotonic() - (3600 * 2)
+        with pool.with_transfer(storage_config) as next_transfer:
+            assert next_transfer == transfer
+        transfer_item.create_time = time.monotonic() - (3600 * 3)
+        with pool.with_transfer(storage_config) as next_transfer:
+            assert next_transfer != transfer
+
+
+def test_transfer_pool_get_oldest() -> None:
+    """Test that when getting a transfer object from a pool, the oldest one available is returned."""
+    storage_config = {"storage_type": "azure"}
+
+    with patch("rohmu.transfer_pool.rohmu_get_transfer") as rohmu_get_transfer:
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_1")
+        pool = transfer_pool.TransferPool()
+
+        with pool.with_transfer(storage_config) as transfer_1:
+            rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_2")
+            with pool.with_transfer(storage_config):
+                # do nothing and put the transfers back in the pool
+                pass
+
+        with pool.with_transfer(storage_config) as next_transfer:
+            assert next_transfer == transfer_1
+
+
+def test_transfer_pool_for_thread_safe_transfer_always_returns_the_same_instance() -> None:
+    """Test that when using a threadsafe transfer object the pool always returns the same instance"""
+    storage_config = {"storage_type": "azure"}
+
+    with patch("rohmu.transfer_pool.rohmu_get_transfer") as rohmu_get_transfer:
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_1", is_thread_safe=True)
+        pool = transfer_pool.TransferPool()
+
+        with pool.with_transfer(storage_config) as transfer_1, pool.with_transfer(storage_config) as transfer_2:
+            assert transfer_1 == transfer_2
+
+
+def test_transfer_pool_for_thread_safe_transfer_does_not_expire() -> None:
+    """Test that a cached transfer object is not returned, if too old, even for thread-safe transfers."""
+    storage_config = {"storage_type": "azure"}
+
+    with patch("rohmu.transfer_pool.rohmu_get_transfer") as rohmu_get_transfer:
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_1", is_thread_safe=True)
+        pool = transfer_pool.TransferPool()
+
+        with pool.with_transfer(storage_config) as transfer:
+            # let's create an item
+            pass
+
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_2", is_thread_safe=True)
+        transfer_item = list(pool._caches.values())[0].transfers_heap[0]  # pylint: disable=protected-access
+        transfer_item.create_time = time.monotonic() - (3600 * 2)
+        with pool.with_transfer(storage_config) as next_transfer:
+            assert next_transfer == transfer
+        transfer_item.create_time = time.monotonic() - (3600 * 3)
+        with pool.with_transfer(storage_config) as next_transfer:
+            # for thread-safe we do not expire the transfers
+            assert next_transfer == transfer
+
+
+# pylint: disable=protected-access
+def test_transfer_pool_get_return_api() -> None:
+    """Test that a cached transfer object is returned, if available."""
+    storage_config_1 = {"storage_type": "azure"}
+    storage_config_2 = {"storage_type": "gcp"}
+
+    with patch("rohmu.transfer_pool.rohmu_get_transfer") as rohmu_get_transfer:
+        pool = transfer_pool.TransferPool()
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_1")
+        safe_transfer = pool.get_transfer(storage_config_1)
+        transfer = safe_transfer._item.transfer
+        rohmu_get_transfer.assert_called_once_with(storage_config_1)
+        assert transfer is not None
+        safe_transfer.return_to_pool()
+
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_2")
+        next_safe_transfer_1 = pool.get_transfer(storage_config_1)
+        assert next_safe_transfer_1._item.transfer == transfer
+        next_safe_transfer_2 = pool.get_transfer(storage_config_2)
+        assert next_safe_transfer_2 is not None
+        assert next_safe_transfer_2._item.transfer != transfer
+
+
+# pylint: disable=protected-access
+def test_transfer_pool_expiration_get_return_api() -> None:
+    """Test that a cached transfer object is not returned, if too old."""
+    storage_config = {"storage_type": "azure"}
+
+    with patch("rohmu.transfer_pool.rohmu_get_transfer") as rohmu_get_transfer:
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_1")
+        pool = transfer_pool.TransferPool()
+
+        safe_transfer = pool.get_transfer(storage_config)
+        transfer_item = safe_transfer._item
+        safe_transfer.return_to_pool()
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_2")
+        transfer_item.create_time = time.monotonic() - (3600 * 2)
+        next_safe_transfer = pool.get_transfer(storage_config)
+        assert next_safe_transfer._item.transfer == transfer_item.transfer
+        next_safe_transfer.return_to_pool()
+        transfer_item.create_time = time.monotonic() - (3600 * 3)
+        next_safe_transfer = pool.get_transfer(storage_config)
+        assert next_safe_transfer._item.transfer != transfer_item.transfer
+
+
+# pylint: disable=protected-access
+def test_transfer_pool_get_oldest_get_return_api() -> None:
+    """Test that when getting a transfer object from a pool, the oldest one available is returned."""
+    storage_config = {"storage_type": "azure"}
+
+    with patch("rohmu.transfer_pool.rohmu_get_transfer") as rohmu_get_transfer:
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_1")
+        pool = transfer_pool.TransferPool()
+
+        safe_transfer_1 = pool.get_transfer(storage_config)
+        transfer_1 = safe_transfer_1._item.transfer
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_2")
+        safe_transfer_2 = pool.get_transfer(storage_config)
+        safe_transfer_1.return_to_pool()
+        safe_transfer_2.return_to_pool()
+
+        next_safe_transfer = pool.get_transfer(storage_config)
+        assert next_safe_transfer._item.transfer == transfer_1
+
+
+# pylint: disable=protected-access
+def test_transfer_pool_for_thread_safe_transfer_always_returns_the_same_instance_get_return_api() -> None:
+    """Test that when using a threadsafe transfer object the pool always returns the same instance"""
+    storage_config = {"storage_type": "azure"}
+
+    with patch("rohmu.transfer_pool.rohmu_get_transfer") as rohmu_get_transfer:
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_1", is_thread_safe=True)
+        pool = transfer_pool.TransferPool()
+
+        transfer_1 = pool.get_transfer(storage_config)
+        transfer_2 = pool.get_transfer(storage_config)
+        assert transfer_1._item.transfer == transfer_2._item.transfer
+
+
+# pylint: disable=protected-access
+def test_transfer_pool_for_thread_safe_transfer_does_not_expire_get_return_api() -> None:
+    """Test that a cached transfer object is not returned, if too old, even for thread-safe transfers."""
+    storage_config = {"storage_type": "azure"}
+
+    with patch("rohmu.transfer_pool.rohmu_get_transfer") as rohmu_get_transfer:
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_1", is_thread_safe=True)
+        pool = transfer_pool.TransferPool()
+
+        safe_transfer = pool.get_transfer(storage_config)
+        transfer_item = safe_transfer._item
+        transfer = transfer_item.transfer
+        safe_transfer.return_to_pool()
+
+        rohmu_get_transfer.return_value = FakeTransfer("mock_transfer_2", is_thread_safe=True)
+
+        transfer_item.create_time = time.monotonic() - (3600 * 2)
+        next_safe_transfer = pool.get_transfer(storage_config)
+        assert next_safe_transfer._item.transfer == transfer
+        next_safe_transfer.return_to_pool()
+        transfer_item.create_time = time.monotonic() - (3600 * 3)
+        next_safe_transfer = pool.get_transfer(storage_config)
+        # We do not expire transfers for thread-safe transfers
+        assert next_safe_transfer._item.transfer == transfer
+
+
+@pytest.mark.parametrize(
+    "attr_name",
+    [
+        "is_thread_safe",
+        "config_model",
+        "prefix",
+        "notifier",
+        "stats",
+        "copy_file",
+        "format_key_for_backend",
+        "format_key_from_backend",
+        "delete_key",
+        "delete_keys",
+        "delete_tree",
+        "get_contents_to_file",
+        "get_contents_to_fileobj",
+        "get_contents_to_string",
+        "get_file_size",
+        "get_metadata_for_key",
+        "list_path",
+        "list_iter",
+        "list_prefixes",
+        "iter_prefixes",
+        "iter_key",
+        "sanitize_metadata",
+        "store_file_from_memory",
+        "store_file_from_disk",
+        "store_file_object",
+        "from_model",
+    ],
+)
+def test_safe_transfer_prevents_access_after_returning(attr_name: str) -> None:
+    """Test that a cached transfer object is not returned, if too old, even for thread-safe transfers."""
+    storage_config = {"storage_type": "azure"}
+
+    with patch("rohmu.transfer_pool.rohmu_get_transfer") as rohmu_get_transfer:
+        rohmu_get_transfer.return_value = LocalTransfer("mock_transfer_1")
+        pool = transfer_pool.TransferPool()
+
+        safe_transfer = pool.get_transfer(storage_config)
+        getattr(safe_transfer, attr_name)
+        safe_transfer.return_to_pool()
+        with pytest.raises(InvalidTransferError):
+            getattr(safe_transfer, attr_name)


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

Implements a transfer-pool API that allows multiple user threads to safely share rohmu transfer objects.

A new `rohmu.transfer_pool` module was added which defines `TransferPool` class. The class provides 2 methods to get a transfer object:

* The `with_transfer(storage_config)` method can be used as context manager
* The `get_transfer(storage_config)` method can be used to obtain a transfer object. This is a proxy that will act exactly as the normal transfer and includes a `return_to_pool` method which MUST be called by the user once they are done. All interactions after this call are prevented.

The module also provides a default pool instance which can be used via the `with_transfer` and `get_transfer` global functions.

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

Various object storage backends are not thread-safe, so users would need to manually handle thread-safety.
This API allows for a simple way to efficiently handle transfer objects in a thread-safe way.


