### PR TITLE
Bump to version 1.1.0

### DIFF
--- a/rohmu/version.py
+++ b/rohmu/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.0.9"
+VERSION = "1.1.0"


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

Bumping to version 1.1.0

Somehow main is at 1.0.9 but PyPI has version 1.0.10 available... I guess in the last release the tag was pushed and the branch deleted instead of being merged into main?

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

I need a new version so that we can update robjecter dependency on rohmu to use new transfer pool.

After merging this to main I will push the tag to trigger the new release.