### PR TITLE
local: fix broken backward compatibility for files without md5 metadata

### DIFF
--- a/rohmu/object_storage/local.py
+++ b/rohmu/object_storage/local.py
@@ -125,14 +125,15 @@ class LocalTransfer(BaseTransfer[Config]):
             return
         st = os.stat(full_path)
         last_modified = datetime.datetime.fromtimestamp(st.st_mtime, tz=datetime.timezone.utc)
+        md5 = metadata.get(INTERNAL_METADATA_KEY_HASH)
         yield IterKeyItem(
             type=KEY_TYPE_OBJECT,
             value={
                 "name": key,
                 "size": st.st_size,
                 "last_modified": last_modified,
-                "md5": metadata[INTERNAL_METADATA_KEY_HASH],
                 "metadata": self._filter_metadata(metadata) if with_metadata else None,
+                **({"md5": md5} if md5 else {}),
             },
         )
 

--- a/rohmu/typing.py
+++ b/rohmu/typing.py
@@ -1,19 +1,8 @@
 from __future__ import annotations
 
 from types import TracebackType
-from typing import Any, Dict, Optional, Type, TYPE_CHECKING, Union
-
-try:
-    from typing import Protocol
-except ImportError:
-    from typing_extensions import Protocol  # type: ignore [assignment]
-
-try:
-    # Remove when dropping support for Python 3.7
-    from pickle import PickleBuffer
-except ImportError:
-    PickleBuffer = bytes  # type: ignore [misc,assignment]
-import mmap
+from typing import Any, Dict, Optional, Protocol, Type, TYPE_CHECKING, Union
+from typing_extensions import Buffer
 
 if TYPE_CHECKING:
     from array import array
@@ -25,15 +14,7 @@ Metadata = Dict[str, Any]
 
 AnyPath = Union[str, bytes, "PathLike[str]", "PathLike[bytes]"]
 
-BinaryData = Union[
-    bytes,
-    bytearray,
-    memoryview,
-    "array[Any]",
-    mmap.mmap,
-    "ctypes._CData",
-    PickleBuffer,
-]
+BinaryData = Buffer
 
 StrOrPathLike = Union[str, "PathLike[str]"]
 

--- a/test/test_object_storage_local.py
+++ b/test/test_object_storage_local.py
@@ -1,10 +1,12 @@
 """Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/"""
 from io import BytesIO
 from rohmu.errors import InvalidByteRangeError
+from rohmu.object_storage.base import KEY_TYPE_OBJECT
 from rohmu.object_storage.local import LocalTransfer
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest.mock import MagicMock
 
+import json
 import os
 import pytest
 
@@ -66,3 +68,41 @@ def test_get_contents_to_fileobj_raises_error_on_invalid_byte_range() -> None:
                 fileobj_to_store_to=BytesIO(),
                 byte_range=(100, 10),
             )
+
+
+def test_can_handle_metadata_without_md5() -> None:
+    with TemporaryDirectory() as destdir:
+        notifier = MagicMock()
+        transfer = LocalTransfer(
+            directory=destdir,
+            notifier=notifier,
+        )
+        test_data = b"test-data"
+        with NamedTemporaryFile() as tmpfile:
+            tmpfile.write(test_data)
+            tmpfile.flush()
+            transfer.store_file_from_disk(key="test_key1", filepath=tmpfile.name)
+
+        # override the metadata file removing the hash.
+        # this simulates files stored by older versions of rohmu
+        target_file = transfer.format_key_for_backend("test_key1")
+        metadata_file = target_file + ".metadata"
+        old_metadata = {"Content-Length": str(len(test_data))}
+        with open(metadata_file, "w") as metadata_fp:
+            json.dump(old_metadata, metadata_fp)
+
+        # we can read the metadata
+        assert transfer.get_metadata_for_key("test_key1") == old_metadata
+        # and we can also load the file information iterating over the storage
+        item = next(transfer.iter_key("test_key1", with_metadata=True, include_key=True))
+        assert item.type == KEY_TYPE_OBJECT
+        result = item.value
+        assert isinstance(result, dict)
+        expected_value = {
+            "name": "test_key1",
+            "size": len(test_data),
+            "metadata": old_metadata,
+        }
+        last_modified = result.pop("last_modified")
+        assert last_modified is not None
+        assert result == expected_value


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

The local driver now considers the hash of the file as optional metadata.

# Why this way

If a user used a previous version of rohmu to save some files, those will not have the hash in the metadata stored. If they used the new rohmu version to list the files it will barf at the missing md5.

We could compute it on the fly but for now simply ignore it if it is missing.

