### PR TITLE
Revert "typing: fix liskov principle errors"

### DIFF
--- a/rohmu/encryptor.py
+++ b/rohmu/encryptor.py
@@ -113,7 +113,7 @@ class EncryptorFile(FileWrap):
         self._check_not_closed()
         return True
 
-    def write(self, data: BinaryData) -> int:
+    def write(self, data: BinaryData) -> int:  # type: ignore [override]
         """Encrypt and write the given bytes"""
         self._check_not_closed()
         if not data:

--- a/rohmu/filewrap.py
+++ b/rohmu/filewrap.py
@@ -88,7 +88,7 @@ class FileWrap(io.BufferedIOBase):
         self._check_not_closed()
         return False
 
-    def write(self, data: BinaryData) -> int:
+    def write(self, data: BinaryData) -> int:  # type: ignore [override]
         """Encrypt and write the given bytes"""
         self._check_not_closed()
         raise io.UnsupportedOperation("Write not supported")

--- a/rohmu/snappyfile.py
+++ b/rohmu/snappyfile.py
@@ -44,7 +44,7 @@ class SnappyFile(FileWrap):
             self.next_fp.flush()
         super().close()
 
-    def write(self, data: BinaryData) -> int:
+    def write(self, data: BinaryData) -> int:  # type: ignore [override]
         self._check_not_closed()
         if self.encr is None:
             raise io.UnsupportedOperation("file not open for writing")

--- a/rohmu/typing.py
+++ b/rohmu/typing.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
 from types import TracebackType
-from typing import Any, Dict, Optional, Protocol, Type, TYPE_CHECKING, Union
-from typing_extensions import Buffer
+from typing import Any, Dict, Optional, Type, TYPE_CHECKING, Union
+
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol  # type: ignore [assignment]
+
+try:
+    # Remove when dropping support for Python 3.7
+    from pickle import PickleBuffer
+except ImportError:
+    PickleBuffer = bytes  # type: ignore [misc,assignment]
+import mmap
 
 if TYPE_CHECKING:
     from array import array
@@ -14,7 +25,15 @@ Metadata = Dict[str, Any]
 
 AnyPath = Union[str, bytes, "PathLike[str]", "PathLike[bytes]"]
 
-BinaryData = Buffer
+BinaryData = Union[
+    bytes,
+    bytearray,
+    memoryview,
+    "array[Any]",
+    mmap.mmap,
+    "ctypes._CData",
+    PickleBuffer,
+]
 
 StrOrPathLike = Union[str, "PathLike[str]"]
 

--- a/rohmu/zstdfile.py
+++ b/rohmu/zstdfile.py
@@ -31,7 +31,7 @@ class _ZstdFileWriter(FileWrap):
         self.next_fp.flush()
         super().close()
 
-    def write(self, data: BinaryData) -> int:
+    def write(self, data: BinaryData) -> int:  # type: ignore [override]
         self._check_not_closed()
         data_as_bytes = bytes(data)
         compressed_data = self._zstd.compress(data_as_bytes)


### PR DESCRIPTION

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

This reverts commit 5c058b759d64fb08919d1f2034e4ae647d4d0e16.

It broke code using older typing_extensions versions.

Instead we use a couple of `type: ignore` comments to stop mypy from complaining.

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

