### PR TITLE
Add python3.11 pipeline to the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.10", "3.9", "3.8"]
+        python-version: ["3.11", "3.10", "3.9", "3.8"]
 
     steps:
       - id: checkout-code
@@ -70,6 +70,7 @@ jobs:
 
       - id: dependencies
         run: |
+          sudo apt-get install -y libsnappy-dev
           pip install -r requirements.txt
           pip install -r requirements.dev.txt
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

Build rohmu also for python3.11

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

We need to install `libsnappy-dev` because otherwise `python-snappy` won't install on python3.11
