### PR TITLE
s3: fix a bug handling addressing style enum value

### DIFF
--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -186,7 +186,7 @@ class S3Transfer(BaseTransfer[Config]):
             if proxy_info:
                 proxies = {"https": get_proxy_url(proxy_info)}
             boto_config = botocore.client.Config(
-                s3={"addressing_style": addressing_style.value},
+                s3={"addressing_style": S3AddressingStyle(addressing_style).value},
                 signature_version=signature_version,
                 proxies=proxies,
                 **timeouts,

--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -83,6 +83,8 @@ def get_proxy_url(proxy_info: dict[str, Union[str, int]]) -> str:
         auth = ""
     host = proxy_info["host"]
     port = proxy_info["port"]
+
+    # Socks5h support is experimental
     if proxy_info.get("type") in {"socks5", "socks5h"}:
         schema = proxy_info.get("type")
     else:

--- a/test/test_from_model.py
+++ b/test/test_from_model.py
@@ -1,5 +1,7 @@
 from rohmu import Config, get_class_for_transfer, get_transfer
-from unittest.mock import MagicMock, Mock, patch
+from rohmu.object_storage.s3 import Config as S3Config, S3Transfer
+from typing import cast
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest
 import sys
@@ -10,22 +12,47 @@ import sys
     [
         {
             "storage_type": "s3",
-            "region": "dummy",
-            "bucket_name": "dummy",
+            "region": "dummy-region",
+            "bucket_name": "dummy-bucket",
             "notifier": {"notifier_type": "http", "url": "localhost"},
         }
     ],
 )
 @patch("rohmu.notifier.http.BackgroundHTTPNotifier")
-@patch("rohmu.object_storage.s3.S3Transfer.from_model")
+@patch("rohmu.object_storage.s3.S3Transfer.check_or_create_bucket")
+@patch("rohmu.object_storage.s3.create_s3_client")
+@patch("rohmu.object_storage.s3.S3Transfer.from_model", wraps=S3Transfer.from_model)
 @patch("rohmu.object_storage.s3.S3Transfer.config_model")
-def test_get_transfer(mock_config_model: Mock, mock_from_model: Mock, mock_notifier: Mock, config: Config) -> None:
-    _transfer = get_transfer(config)
+def test_get_transfer_s3(
+    mock_config_model: Mock,
+    mock_from_model: Mock,
+    mock_s3_client: Mock,
+    mock_check_or_create: Mock,
+    mock_notifier: Mock,
+    config: Config,
+) -> None:
+
     expected_config_arg = dict(config)
     expected_config_arg.pop("storage_type")
     expected_config_arg.pop("notifier")
+    mock_config_model.return_value = S3Config(**expected_config_arg, notifier=None)
+
+    transfer_object = get_transfer(config)
+
     mock_config_model.assert_called_once_with(**expected_config_arg, notifier=mock_notifier())
     mock_from_model.assert_called_once_with(mock_config_model())
+    assert isinstance(transfer_object, S3Transfer)
+    # cast was the easiest way to convince mypy
+    assert cast(S3Transfer, transfer_object).bucket_name == "dummy-bucket"
+    mock_s3_client.assert_called_once_with(
+        session=ANY,
+        config=ANY,
+        aws_access_key_id=None,
+        aws_secret_access_key=None,
+        aws_session_token=None,
+        region_name="dummy-region",
+    )
+    assert mock_check_or_create.called
 
 
 @pytest.mark.parametrize("storage_type", ["s3", "local", "azure", "google", "swift", "s3"])


### PR DESCRIPTION
Fix a bug when `rohmu.get_transfer()` is passing addressing style enum values from Config to create S3Transfer object. Also improves `test_from_model` to find similar issues.