### PR TITLE
rohmu: fix Range header syntax for S3 implementation

### DIFF
--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -322,7 +322,7 @@ class S3Transfer(BaseTransfer[Config]):
         path = self.format_key_for_backend(key, remove_slash_prefix=True)
         kwargs: dict[str, Any] = {}
         if byte_range:
-            kwargs["Range"] = f"bytes {byte_range[0]}-{byte_range[1]}"
+            kwargs["Range"] = f"bytes={byte_range[0]}-{byte_range[1]}"
         try:
             # Actual usage is accounted for in
             # _read_object_to_fileobj, although that omits the initial


### PR DESCRIPTION


<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

HTTP specs specify = as separator between unit and the ranges, not space. We already use the correct syntax for multipart.

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

