### PR TITLE
docs: remove version import from conf.py for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,3 +82,28 @@ jobs:
         uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b
         with:
           verbose: true
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - id: checkout-src-docs
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          path: pr
+
+      - id: checkout-gh-pages
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          path: gh-pages
+          ref: gh-pages
+
+      - id: prepare-python
+        uses: actions/setup-python@v4
+
+      - id: prepare-sphinx
+        run: pip install sphinx==4.5.0 sphinx-rtd-theme==1.0.0
+
+      - id: run-sphinx
+        run: sphinx-build -b html pr/docs gh-pages -E -d $GITHUB_WORKSPACE/.doctree

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,11 +12,8 @@
 #
 import os
 import sys
-from rohmu.version import VERSION
 
 sys.path.insert(0, os.path.abspath(".."))
-
-
 # -- Project information -----------------------------------------------------
 
 project = "Rohmu"
@@ -24,7 +21,7 @@ copyright = "2022, Aiven"
 author = "Aiven"
 
 # The full version, including alpha/beta/rc tags
-release = VERSION
+release = "1.1.2"
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
For now importing `rohmu.version` would also require importing other `rohmu` dependencies, this removes the import in `docs/conf.py`, and also adds a github action that runs sphinx-build on pull requests (without pushing the generated docs to `gh-pages`).