### PR TITLE
misc: fix sphinx GitHub Actions workflow

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -39,7 +39,7 @@ jobs:
           git add -A
           git config --global user.email "$(git show --format=%ae -s)"
           git config --global user.name "$(git show --format=%an -s)"
-          git commit -m "From $GITHUB_REF $(echo ${GITHUB_SHA} | cut -c 1-8)"
+          git diff-index --quiet HEAD || git commit -m "From $GITHUB_REF $(echo ${GITHUB_SHA} | cut -c 1-8)"
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git push
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

misc: fix sphinx GitHub Actions workflow

# Why this way

Previously, `git commit ...` failed while trying to commit no changes. To prevent this, check changes first.

