### PR TITLE
Follow-up to address previous PR comments

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,5 @@
 # same versions than pghoard this must reviewed and pinned
 black==23.7.0
-mock
 mypy==1.5.1
 # Same version from pghoard
 pylint==2.17.4

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,8 +1,9 @@
-# same versions than pghoard this must reviewed and pinned
+# Kept in sync with the versions in CI
 black==23.7.0
 mypy==1.5.1
-# Same version from pghoard
 pylint==2.17.4
+isort==5.11.5
+# Unpinned dependencies, latest is fine
 botocore
 botocore-stubs
 mypy_boto3_s3
@@ -12,8 +13,6 @@ pytest-cov
 pytest-mock
 pytest-timeout
 pytest-asyncio
-# Same version from pghoard
-isort==5.10.1
 types-python-dateutil
 types-paramiko
 types-botocore

--- a/test/delta/test_snapshot.py
+++ b/test/delta/test_snapshot.py
@@ -7,8 +7,8 @@ from rohmu.delta.common import BackupPath, EMBEDDED_FILE_SIZE, Progress, SizeLim
 from rohmu.typing import AnyPath
 from test.conftest import SnapshotterWithDefaults
 from typing import Any, Callable, Union
+from unittest.mock import patch
 
-import mock
 import os
 import pytest
 
@@ -87,7 +87,7 @@ def test_snapshot_error_filenotfound(
 
     snapshotter = snapshotter_creator()
     obj = obj or snapshotter
-    with mock.patch.object(obj, fun, new=_not_really_found):
+    with patch.object(obj, fun, new=_not_really_found):
         (snapshotter.src / "foo").write_text("foobar")
         (snapshotter.src / "bar").write_text("foobar")
         with snapshotter.lock:
@@ -189,16 +189,16 @@ def test_snapshot_error_when_required_files_not_found(snapshotter_creator: Calla
         # Required file disappeared during hash calculation
         # should succeed if we re-use snapshot files from previous snapshot, as there will be no new snapshot files
         # created
-        with mock.patch.object(SnapshotFile, "open_for_reading", new=fake_open_for_reading):
+        with patch.object(SnapshotFile, "open_for_reading", new=fake_open_for_reading):
             snapshotter.snapshot(progress=Progress(), reuse_old_snapshotfiles=True)
         validate_snapshot()
 
         # Should fail when files are not re-used and required file is missing
-        with mock.patch.object(SnapshotFile, "open_for_reading", new=fake_open_for_reading):
+        with patch.object(SnapshotFile, "open_for_reading", new=fake_open_for_reading):
             with pytest.raises(FileNotFoundError):
                 snapshotter.snapshot(progress=Progress(), reuse_old_snapshotfiles=False)
 
         # Should fail when files disappeared before hash calculation
-        with mock.patch("rohmu.delta.snapshot.Path.stat", side_effect=FileNotFoundError):
+        with patch("rohmu.delta.snapshot.Path.stat", side_effect=FileNotFoundError):
             with pytest.raises(FileNotFoundError):
                 snapshotter.snapshot(progress=Progress(), reuse_old_snapshotfiles=True)


### PR DESCRIPTION
# About this change - What it does

- Add a comment regarding frozen requirements kept in sync with CI.
- Stop using deprecated `mock` package, migrate to `unittest.mock` instead