### PR TITLE
object_storage: avoid uploading empty file by multiparts

### DIFF
--- a/rohmu/object_storage/s3.py
+++ b/rohmu/object_storage/s3.py
@@ -493,7 +493,8 @@ class S3Transfer(BaseTransfer[Config]):
         progress_fn: ProgressProportionCallbackType = None,  # pylint: disable=unused-argument
     ) -> None:
         path = self.format_key_for_backend(key, remove_slash_prefix=True)
-        data = bytes(memstring)  # make sure Body is of type bytes as memoryview's not allowed, only bytes/bytearrays
+        # make sure Body is of type bytes as memoryview's not allowed, only bytes/bytearrays
+        data = bytes(memstring) if len(memstring) else b""
         args: dict[str, Any] = {
             "Bucket": self.bucket_name,
             "Body": data,
@@ -524,7 +525,7 @@ class S3Transfer(BaseTransfer[Config]):
         upload_progress_fn: IncrementalProgressCallbackType = None,
     ) -> None:  # pylint: disable=unused-argument
         if not self._should_multipart(
-            chunk_size=self.multipart_chunk_size, default=True, metadata=metadata, multipart=multipart
+            fd=fd, chunk_size=self.multipart_chunk_size, default=True, metadata=metadata, multipart=multipart
         ):
             data = fd.read()
             self.store_file_from_memory(key, data, metadata, cache_control=cache_control, mimetype=mimetype)

--- a/rohmu/object_storage/swift.py
+++ b/rohmu/object_storage/swift.py
@@ -295,7 +295,7 @@ class SwiftTransfer(BaseTransfer[Config]):
         metadata = metadata or {}
         content_length = metadata.get("Content-Length")
         multipart = self._should_multipart(
-            chunk_size=self.segment_size, default=True, metadata=metadata, multipart=multipart
+            fd=fd, chunk_size=self.segment_size, default=True, metadata=metadata, multipart=multipart
         )
         self._store_file_contents(
             key,

--- a/rohmu/util.py
+++ b/rohmu/util.py
@@ -56,6 +56,19 @@ def set_stream_nonblocking(stream: HasFileno) -> None:
     fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
 
+def file_object_is_empty(fd: BinaryIO) -> bool:
+    # not seekable, so we cannot verify it has no contents
+    if not fd.seekable():
+        return False
+
+    fd.seek(0)
+    is_empty = len(fd.read(1)) == 0
+
+    # rewind file
+    fd.seek(0)
+    return is_empty
+
+
 T = TypeVar("T")
 
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from io import BytesIO, UnsupportedOperation
-from rohmu.util import BinaryStreamsConcatenation, get_total_size_from_content_range, ProgressStream
+from rohmu.util import BinaryStreamsConcatenation, file_object_is_empty, get_total_size_from_content_range, ProgressStream
 from typing import Optional
 
 import pytest
@@ -77,3 +77,8 @@ def test_progress_stream() -> None:
         # check that __exit__ closes the file
         pass
     assert progress_stream.closed
+
+
+def test_file_object_is_empty() -> None:
+    assert not file_object_is_empty(BytesIO(b"Hello, World!\nSecond line\nThis is a longer third line\n"))
+    assert file_object_is_empty(BytesIO(b""))


### PR DESCRIPTION
When trying to upload an empty file by multipart for S3, botocore starts raising MalformedXML. In order to avoid this, rohmu should just verify if the file object is empty and just upload it entirely

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Verifies if file object to be upload is empty, in this case multipart upload must not be used.
<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #BF-2320

# Why this way

For S3, by default rohmu will always attempt multipart uploads (regardless if the content length is 0). For some storages this can be an issue, therefore we should just put directly the object into the storage. In case the file's metadata does not contain the content length and the file object is seekable, rohmu should just check if the file is indeed empty and always avoid multipart upload
