### PR TITLE
verify if provided object has seekable function when verifying if its empty

### DIFF
--- a/rohmu/util.py
+++ b/rohmu/util.py
@@ -58,7 +58,7 @@ def set_stream_nonblocking(stream: HasFileno) -> None:
 
 def file_object_is_empty(fd: BinaryIO) -> bool:
     # not seekable, so we cannot verify it has no contents
-    if not fd.seekable():
+    if not hasattr(fd, "seekable") or not fd.seekable():
         return False
 
     fd.seek(0)


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
Just check if file-like object has `seekable` attribute.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #BF-2320


